### PR TITLE
feat: add Austria (AT) — RIS OGD API parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Each law is a file. Each reform is a commit. Every country is a repo.
 
 ## What it does
 
-1. **Fetches** legislation from official open data sources (BOE for Spain, LEGI for France)
+1. **Fetches** legislation from official open data sources (BOE for Spain, LEGI for France, RIS for Austria)
 2. **Parses** XML into structured data (articles, versions, reforms)
 3. **Generates** Markdown files with YAML frontmatter and git commits with historical dates
 
@@ -16,6 +16,7 @@ Each law is a file. Each reform is a commit. Every country is a repo.
 |---------|------|------|--------|
 | Spain | [legalize-es](https://github.com/legalize-dev/legalize-es) | 8,642 | BOE |
 | France | [legalize-fr](https://github.com/legalize-dev/legalize-fr) | 80 codes | LEGI (Legifrance) |
+| Austria | legalize-at _(coming soon)_ | ~20k+ | RIS OGD API |
 
 ## Architecture
 
@@ -24,6 +25,7 @@ src/legalize/
   fetcher/          # Download from official APIs
     client.py         BOE HTTP client (Spain)
     client_legi.py    LEGI XML dump reader (France)
+    client_ris.py     RIS HTTP client (Austria)
     base.py           Abstract interfaces (add new countries here)
   transformer/      # XML -> Markdown
     xml_parser.py     BOE XML -> Bloque/Version
@@ -40,6 +42,7 @@ src/legalize/
   storage.py        # Save XML + JSON to data/ (intermediate cache)
   pipeline.py       # Spain orchestration
   pipeline_fr.py    # France orchestration
+  pipeline_at.py    # Austria orchestration
 ```
 
 ## Quick start
@@ -67,6 +70,10 @@ legalize status                   # Show pipeline status
 # France
 legalize fetch-fr --discover --legi-dir /path/to/legi  # Process LEGI dump
 legalize bootstrap-fr --legi-dir /path/to/legi         # Full bootstrap
+
+# Austria
+legalize fetch-at --discover   # Discover all Gesetzesnummern from RIS API
+legalize bootstrap-at          # Full bootstrap (~20k Gesetze, ~3h)
 ```
 
 ## Adding a new country
@@ -87,6 +94,7 @@ See `fetcher/client_legi.py` (France) as a reference implementation.
 |---------|--------|--------|------|------|
 | Spain | Live | [BOE](https://www.boe.es/) | 8,642 | [legalize-es](https://github.com/legalize-dev/legalize-es) |
 | France | Beta | [Legifrance](https://www.legifrance.gouv.fr/) | 80 codes | [legalize-fr](https://github.com/legalize-dev/legalize-fr) |
+| Austria | In Progress | [RIS OGD](https://data.bka.gv.at/ris/api/v2.6/) | ~20k+ | legalize-at |
 | Germany | Wanted | [BGBL](https://www.bgbl.de/) | — | Help wanted! |
 | Portugal | Wanted | [DRE](https://dre.pt/) | — | Help wanted! |
 


### PR DESCRIPTION
## Austria (AT) — Bundesrecht via RIS OGD API

Adds full support for Austrian federal legislation from the [RIS open data API](https://data.bka.gv.at/ris/api/v2.6/).

**Data source:** https://data.bka.gv.at/ris/api/v2.6/
**License:** CC BY 4.0 ([OGD Austria](https://www.data.gv.at))
**Coverage:** Bundesrecht konsolidiert (BrKons) — ~437k NOR entries / ~20k+ Gesetze

---

### What this PR adds

Implements the 4 interfaces from `fetcher/base.py`:

| Component | File | Description |
|---|---|---|
| `RISClient` | `fetcher/client_ris.py` | HTTP client for `data.bka.gv.at/ris/api/v2.6/` |
| `RISDiscovery` | `fetcher/discovery_ris.py` | Paginates all NOR entries, yields unique `Gesetzesnummern` |
| `RISTextParser` | `fetcher/parser_ris.py` | Parses RIS XML (BKA namespace) → `Bloque`/`Version` |
| `RISMetadataParser` | `fetcher/parser_ris.py` | Parses JSON API response → `NormaMetadata` |

Plus:
- `pipeline_at.py` — `fetch_one_at` / `fetch_all_at` / `bootstrap_at`
- Austria `Rango` mappings in `transformer/slug.py`
- `"at"` entry in `countries.py` registry
- 16 tests with real fixture data (2 fixtures downloaded from live API)

---

### RIS data model

The RIS API works differently from BOE/LEGI:

- Each **NOR document** (e.g. `NOR12030057`) represents one paragraph/article
- A **Gesetzesnummer** (e.g. `10002333`) groups all NOR paragraphs of one law
- `Gesetzesnummer` is used as the stable norm ID (NOR IDs can change)
- XML uses the BKA namespace: `http://www.bka.gv.at`

### Austrian Rango hierarchy

```
bundesverfassungsgesetz → bundesverfassungsgesetze/
bundesgesetz            → bundesgesetze/
verordnung              → verordnungen/
kundmachung             → kundmachungen/
erlass                  → erlaesse/
staatsvertrag           → staatsvertraege/
```

---

### Scale & performance

- Full bootstrap: ~437k HTTP requests at 0.5s/req ≈ ~3h (one-time)
- Daily updates: `discover_daily(date)` uses `Geaendert` filter → typically minutes
- Reform history (Novellen cross-references) returns `[]` for now — requires the separate `/History` endpoint

---

### Tests

```
26 passed in 0.04s
```

All existing tests still pass. New tests cover parser, metadata, countries dispatch, and slug mappings.