### PR TITLE
feat(ad): add Andorra fetcher (106 laws)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -108,3 +108,11 @@ countries:
         - "decretos-ley"
         - "constitucion"
       law_number_max: 20500
+
+  ad:
+    repo_path: "../countries/ad"
+    data_dir: "../countries/data-ad"
+    max_workers: 1
+    source:
+      base_url: "https://raw.githubusercontent.com/ericrisco/legalize-ad/main/data"
+      requests_per_second: 5.0

--- a/src/legalize/countries.py
+++ b/src/legalize/countries.py
@@ -78,6 +78,12 @@ REGISTRY: dict[str, dict[str, tuple[str, str]]] = {
         "text_parser": ("legalize.fetcher.uy.parser", "IMPOTextParser"),
         "metadata_parser": ("legalize.fetcher.uy.parser", "IMPOMetadataParser"),
     },
+    "ad": {
+        "client": ("legalize.fetcher.ad.client", "ADClient"),
+        "discovery": ("legalize.fetcher.ad.discovery", "ADDiscovery"),
+        "text_parser": ("legalize.fetcher.ad.parser", "ADTextParser"),
+        "metadata_parser": ("legalize.fetcher.ad.parser", "ADMetadataParser"),
+    },
     # To add a new country:
     # 1. Create fetcher/{code}/ with client.py, discovery.py, parser.py
     # 2. Register here

--- a/src/legalize/fetcher/ad/__init__.py
+++ b/src/legalize/fetcher/ad/__init__.py
@@ -1,0 +1,11 @@
+"""Andorra (AD) -- legislative fetcher components.
+
+Source: jurisprudencia.ad (https://jurisprudencia.ad/)
+Format: JSON data files hosted at github.com/ericrisco/legalize-ad/data/
+"""
+
+from legalize.fetcher.ad.client import ADClient
+from legalize.fetcher.ad.discovery import ADDiscovery
+from legalize.fetcher.ad.parser import ADMetadataParser, ADTextParser
+
+__all__ = ["ADClient", "ADDiscovery", "ADTextParser", "ADMetadataParser"]

--- a/src/legalize/fetcher/ad/client.py
+++ b/src/legalize/fetcher/ad/client.py
@@ -1,0 +1,64 @@
+"""Andorra HTTP client -- fetches JSON data from GitHub.
+
+Data source: https://jurisprudencia.ad/
+Data files: https://github.com/ericrisco/legalize-ad/tree/main/data
+Format: JSON files (one per law), following the storage.py format.
+
+The data is extracted from jurisprudencia.ad and published as structured
+JSON to the legalize-ad repo. This client fetches them via
+raw.githubusercontent.com.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from legalize.fetcher.base import HttpClient
+
+if TYPE_CHECKING:
+    from legalize.config import CountryConfig
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE = (
+    "https://raw.githubusercontent.com/ericrisco/legalize-ad/main/data"
+)
+
+
+class ADClient(HttpClient):
+    """HTTP client for Andorran legislation JSON files on GitHub."""
+
+    @classmethod
+    def create(cls, country_config: CountryConfig) -> ADClient:
+        source = country_config.source or {}
+        return cls(
+            base_url=source.get("base_url", _DEFAULT_BASE),
+            requests_per_second=source.get("requests_per_second", 5.0),
+        )
+
+    def __init__(
+        self,
+        base_url: str = _DEFAULT_BASE,
+        requests_per_second: float = 5.0,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            requests_per_second=requests_per_second,
+            max_retries=3,
+            request_timeout=30,
+        )
+
+    def get_text(self, norm_id: str) -> bytes:
+        """Fetch the JSON for a law. Text and metadata are in the same file."""
+        url = f"{self._base_url}/{norm_id}.json"
+        return self._get(url)
+
+    def get_metadata(self, norm_id: str) -> bytes:
+        """Metadata is embedded in the JSON, same file as text."""
+        return self.get_text(norm_id)
+
+    def get_index(self) -> bytes:
+        """Fetch the index.json listing all available laws."""
+        url = f"{self._base_url}/index.json"
+        return self._get(url)

--- a/src/legalize/fetcher/ad/discovery.py
+++ b/src/legalize/fetcher/ad/discovery.py
@@ -1,0 +1,44 @@
+"""Discovery of Andorran legislation via index.json on GitHub.
+
+The index is generated from jurisprudencia.ad data and published
+to the legalize-ad repo.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from datetime import date
+
+from legalize.fetcher.ad.client import ADClient
+from legalize.fetcher.base import LegislativeClient, NormDiscovery
+
+logger = logging.getLogger(__name__)
+
+
+class ADDiscovery(NormDiscovery):
+    """Discovers Andorran laws from an index.json hosted on GitHub."""
+
+    def discover_all(self, client: LegislativeClient, **kwargs) -> Iterator[str]:
+        """Yield all norm IDs from the index."""
+        assert isinstance(client, ADClient)
+        index_data = client.get_index()
+        index = json.loads(index_data)
+
+        for entry in index:
+            yield entry["identifier"]
+
+    def discover_daily(
+        self, client: LegislativeClient, target_date: date, **kwargs
+    ) -> Iterator[str]:
+        """Yield norm IDs updated on or after target_date."""
+        assert isinstance(client, ADClient)
+        index_data = client.get_index()
+        index = json.loads(index_data)
+
+        for entry in index:
+            last_updated = date.fromisoformat(entry["last_updated"])
+            if last_updated >= target_date:
+                logger.info("Updated: %s (last_updated: %s)", entry["identifier"], last_updated)
+                yield entry["identifier"]

--- a/src/legalize/fetcher/ad/parser.py
+++ b/src/legalize/fetcher/ad/parser.py
@@ -1,0 +1,82 @@
+"""Parser for Andorran legislation JSON files.
+
+The JSON files are generated from jurisprudencia.ad and follow the
+legalize-pipeline storage.py format, so parsing is straightforward.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any
+
+from legalize.fetcher.base import MetadataParser, TextParser
+from legalize.models import (
+    Block,
+    NormMetadata,
+    NormStatus,
+    Paragraph,
+    Rank,
+    Version,
+)
+
+
+class ADTextParser(TextParser):
+    """Parses Andorra JSON into Block objects."""
+
+    def parse_text(self, data: bytes) -> list[Any]:
+        """Parse JSON into Blocks with versioned content."""
+        parsed = json.loads(data)
+        blocks: list[Block] = []
+
+        for art in parsed["articles"]:
+            versions = []
+            for v in art["versions"]:
+                paragraphs = []
+                css_classes = v.get("css_classes")
+                if v["text"].strip():
+                    lines = [ln.strip() for ln in v["text"].split("\n\n") if ln.strip()]
+                    for i, line in enumerate(lines):
+                        css = css_classes[i] if css_classes and i < len(css_classes) else "parrafo"
+                        paragraphs.append(Paragraph(css_class=css, text=line))
+                versions.append(
+                    Version(
+                        norm_id=v["source_id"],
+                        publication_date=date.fromisoformat(v["date"]),
+                        effective_date=date.fromisoformat(v["date"]),
+                        paragraphs=tuple(paragraphs),
+                    )
+                )
+
+            blocks.append(
+                Block(
+                    id=art["block_id"],
+                    block_type=art["block_type"],
+                    title=art["title"],
+                    versions=tuple(versions),
+                )
+            )
+
+        return blocks
+
+
+class ADMetadataParser(MetadataParser):
+    """Parses Andorra JSON metadata into NormMetadata."""
+
+    def parse(self, data: bytes, norm_id: str) -> NormMetadata:
+        """Parse JSON metadata."""
+        parsed = json.loads(data)
+        meta = parsed["metadata"]
+
+        return NormMetadata(
+            title=meta["title"],
+            short_title=meta["title"],
+            identifier=meta["identifier"],
+            country="ad",
+            rank=Rank(meta["rank"]),
+            publication_date=date.fromisoformat(meta["publication_date"]),
+            status=NormStatus(meta["status"]),
+            department="Govern del Principat d'Andorra",
+            source=meta["source"],
+            last_modified=date.fromisoformat(meta["last_updated"]),
+        )


### PR DESCRIPTION
## Summary

Adds Andorra (AD) as a new country to the pipeline. 106 laws with full version history.

**Data source:** [jurisprudencia.ad](https://jurisprudencia.ad) -- the Andorran legislation and case law search engine, maintained by [@ericrisco](https://github.com/ericrisco).

**Why not scrape the BOPA directly?** The BOPA (Butlletí Oficial del Principat d'Andorra) only publishes original texts and amendments as separate documents -- not consolidated versions. The data in legalize-ad comes from fully consolidated texts maintained at jurisprudencia.ad, which is what the pipeline needs to generate meaningful diffs.

**How it works:** The data is published as structured JSON files to [ericrisco/legalize-ad/data/](https://github.com/ericrisco/legalize-ad/tree/main/data). The fetcher reads these JSONs via `raw.githubusercontent.com`, similar to how France reads from a local LEGI dump. When laws change, I update the JSONs and push.

### Components

- `fetcher/ad/client.py` -- `ADClient(HttpClient)`: fetches `{code_id}.json` from GitHub
- `fetcher/ad/discovery.py` -- `ADDiscovery`: reads `index.json` for the law catalog
- `fetcher/ad/parser.py` -- `ADTextParser` + `ADMetadataParser`: deserializes JSON into `Block`/`NormMetadata`
- Registered in `countries.py` and `config.yaml`

### Data format

Each JSON follows the `storage.py` format (`load_norma_from_json` compatible):

```json
{
  "metadata": { "title", "identifier", "country": "ad", "rank", ... },
  "articles": [ { "block_id", "block_type", "title", "versions": [...] } ],
  "reforms": [ { "date", "source_id", "affected_block_ids": [...] } ]
}
```

### Coverage

- 106 laws (105 codes + Constitution of Andorra)
- Full version history (e.g., Codi Penal has 28 versions, 2005-2025)
- Output repo: [ericrisco/legalize-ad](https://github.com/ericrisco/legalize-ad) (523 historical commits)

Related: legalize-dev/legalize#7