### PR TITLE
chore: decouple engine from web, move scripts to fetcher dirs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Legalize is a multi-country platform that converts official legislation into ver
 │   ├── {code}/          ← country repos (legalize-{code}), cloned on demand
 │   └── data-{code}/     ← data caches (no git), regenerable via fetch
 ├── hub/                 ← public hub repo (legalize-dev/legalize)
-└── web/                 ← legalize.dev website
+└── web/                 ← legalize.dev website (separate repo)
 ```
 
 The local `countries/` directory may be empty. Do not assume repos or data dirs exist locally. Always check before running commands that depend on them.
@@ -64,7 +64,7 @@ source: "https://www.boe.es/eli/es/c/1978/12/27/(1)"
 ---
 ```
 
-Country-specific extras go in an `extra` sub-mapping (or as additional frontmatter keys for fields the web DB consumes).
+Country-specific extras go in an `extra` sub-mapping (or as additional frontmatter keys for fields downstream consumers need).
 
 **Commit message types:** `[bootstrap]`, `[reforma]`, `[nueva]`, `[derogacion]`, `[correccion]`, `[fix-pipeline]`
 
@@ -93,7 +93,7 @@ High-level order:
 6. Write parser tests against the 5 fixtures.
 7. **Quality gate (mandatory):** fetch 5 sample laws, render to Markdown, and run an AI review covering TEXT correctness, METADATA completeness, STRUCTURE, RICH FORMATTING preservation, and ENCODING. Do not proceed until 5/5 PASS.
 8. Tune `max_workers` against a 50-law benchmark.
-9. Full bootstrap → `legalize health` → push country repo → open engine PR → coordinate with the web team for sync wiring → verify on https://legalize.dev/{code}.
+9. Full bootstrap → `legalize health` → push country repo → open engine PR → verify on https://legalize.dev/{code}.
 
 **Non-negotiable rules for the parser:**
 

--- a/src/legalize/fetcher/gr/parser.py
+++ b/src/legalize/fetcher/gr/parser.py
@@ -1014,8 +1014,8 @@ class GreekMetadataParser(MetadataParser):
     def _collect_amend_refs(text: str) -> list[tuple[str, str]]:
         """Collect cross-references to other laws and decrees.
 
-        Stored under ``extra.amends`` so the web app can render an
-        "amends/amended-by" backlink section without having to re-scan
+        Stored under ``extra.amends`` so downstream consumers can render
+        an "amends/amended-by" backlink section without having to re-scan
         the Markdown body.
 
         Sort order: by **year descending then number descending** so the

--- a/src/legalize/fetcher/lv/parser.py
+++ b/src/legalize/fetcher/lv/parser.py
@@ -157,7 +157,7 @@ def _parse_dotted_date(s: str) -> date | None:
 # C0 control chars (except \t, \n, \r) and C1 control chars (0x80-0x9F).
 # These are never legitimately in text but occasionally leak from likumi.lv
 # source data (e.g. U+009A between "pa" and "švaldības" in id=305766 breaks
-# YAML parsing in the web sync).
+# YAML parsing downstream).
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
 

--- a/src/legalize/fetcher/se/refetch.py
+++ b/src/legalize/fetcher/se/refetch.py
@@ -6,18 +6,15 @@ Riksdagen discovery pagination. Also discovers new norms from
 2017-2026 by paginating from a specific start page.
 
 Usage:
-    python scripts/refetch_se.py              # re-fetch all existing + discover new
-    python scripts/refetch_se.py --limit 10   # test with 10 norms
+    python -m legalize.fetcher.se.refetch              # re-fetch all existing + discover new
+    python -m legalize.fetcher.se.refetch --limit 10   # test with 10 norms
 """
 
 import argparse
 import logging
 import re
-import sys
 import time
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from legalize.config import load_config
 from legalize.pipeline import generic_fetch_one
@@ -37,9 +34,8 @@ def extract_norm_ids_from_json(json_dir: Path) -> list[str]:
 
 def discover_recent(start_page: int = 488) -> list[str]:
     """Discover base statute SFS numbers from a specific page onward."""
-    from legalize.fetcher.se.discovery import SwedishDiscovery, _is_amendment
+    from legalize.fetcher.se.discovery import _is_amendment
 
-    import json
     import requests
 
     seen: set[str] = set()
@@ -65,7 +61,7 @@ def discover_recent(start_page: int = 488) -> list[str]:
                 break
             except Exception as e:
                 if attempt < 2:
-                    time.sleep(2 ** attempt)
+                    time.sleep(2**attempt)
                 else:
                     print(f"  Error on page {page} after 3 attempts: {e}")
         if result is None:
@@ -102,8 +98,9 @@ def discover_recent(start_page: int = 488) -> list[str]:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--limit", type=int, default=None)
-    parser.add_argument("--skip-existing", action="store_true",
-                        help="Only discover and fetch new norms (2017+)")
+    parser.add_argument(
+        "--skip-existing", action="store_true", help="Only discover and fetch new norms (2017+)"
+    )
     args = parser.parse_args()
 
     config = load_config()
@@ -115,7 +112,9 @@ def main():
         existing_ids = []
     else:
         existing_ids = extract_norm_ids_from_json(json_dir)
-        print(f"Existing norms: {existing_ids[-1] if existing_ids else 'none'} ({len(existing_ids)})")
+        print(
+            f"Existing norms: {existing_ids[-1] if existing_ids else 'none'} ({len(existing_ids)})"
+        )
 
     # Phase 2: discover new norms (2017-2026)
     print("Discovering new norms from 2017+...")
@@ -127,7 +126,7 @@ def main():
 
     all_ids = existing_ids + truly_new
     if args.limit:
-        all_ids = all_ids[:args.limit]
+        all_ids = all_ids[: args.limit]
 
     print(f"\nTotal to fetch: {len(all_ids)}")
     print(f"Estimated time: ~{len(all_ids) * 3 / 10 / 60:.0f} minutes\n")
@@ -152,8 +151,10 @@ def main():
             elapsed = time.time() - t0
             rate = i / elapsed if elapsed > 0 else 0
             eta = (len(all_ids) - i) / rate / 60 if rate > 0 else 0
-            print(f"  [{i}/{len(all_ids)}] {fetched} OK, {errors} errors "
-                  f"({rate:.1f}/s, ETA {eta:.0f}m)")
+            print(
+                f"  [{i}/{len(all_ids)}] {fetched} OK, {errors} errors "
+                f"({rate:.1f}/s, ETA {eta:.0f}m)"
+            )
 
     elapsed = time.time() - t0
     print(f"\nDone in {elapsed / 60:.1f}m: {fetched} fetched, {errors} errors")

--- a/src/legalize/fetcher/uy/catalog.py
+++ b/src/legalize/fetcher/uy/catalog.py
@@ -8,7 +8,7 @@ result to `<data_dir>/catalog.json`. Subsequent calls to
 re-probing.
 
 Usage:
-    python scripts/build_uy_catalog.py [--start 9000] [--end 20500] [--workers 16]
+    python -m legalize.fetcher.uy.catalog [--start 9000] [--end 20500] [--workers 16]
 """
 
 from __future__ import annotations

--- a/src/legalize/pipeline.py
+++ b/src/legalize/pipeline.py
@@ -425,8 +425,8 @@ def generic_bootstrap(
     # critically, sorts commits by publication date so the resulting git
     # history is chronological. The slow commit_all() walks json files in
     # filename order, which for countries with mixed pre/post-1970 laws
-    # leaves clamped 1970-01-02 commits at HEAD and breaks the web's
-    # incremental sync (`?since=…` filter on committer date returns 0).
+    # leaves clamped 1970-01-02 commits at HEAD and breaks downstream
+    # incremental sync (committer-date filter returns 0).
     total_commits = commit_all_fast(config, country, dry_run=dry_run)
 
     write_country_meta(config, country)
@@ -757,7 +757,7 @@ def bootstrap_from_local_xml(
 def write_country_meta(config: Config, country: str) -> None:
     """Write country_meta.yaml alongside the JSON data.
 
-    This file helps the web seed script auto-detect countries
+    This file helps downstream tooling auto-detect countries
     and suggest configuration for new ones.
     """
     import yaml

--- a/src/legalize/storage.py
+++ b/src/legalize/storage.py
@@ -97,7 +97,7 @@ def _norm_to_dict(norm: ParsedNorm) -> dict:
         metadata_dict["jurisdiction"] = meta.jurisdiction
 
     # Extra: country-specific fields (department, summary, pdf_url, etc.)
-    # These go into a single dict for the web's JSONB column.
+    # These go into a single dict for the extra JSONB column downstream.
     extra_dict: dict[str, str] = {}
     if meta.department:
         extra_dict["department"] = meta.department


### PR DESCRIPTION
## Summary

- **Remove all web references from engine** — the engine produces git repos; whoever consumes them is downstream and not the engine's concern. Replaced 5 comments mentioning "web app/DB/sync/seed" with architecture-agnostic phrasing ("downstream consumers/tooling").
- **Move country scripts to fetcher dirs** — `scripts/build_uy_catalog.py` → `fetcher/uy/catalog.py`, `scripts/refetch_se.py` → `fetcher/se/refetch.py`. Matches the existing pattern (ES has `catalogo.py`/`daily.py`, EE has `bootstrap.py`/`history.py` inside their fetcher packages). `scripts/` now only contains the generic `check-dispatch.py` pre-commit hook.

## Test plan

- [x] 798 passed / 25 skipped
- [x] `git grep -i "web app\|web DB\|web sync\|web seed\|web's\|legalize-web"` returns 0 hits (excluding "website", "azurewebsites", "AppleWebKit", "webhooks")
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)