### PR TITLE
ci: add pl, uy, gr to daily-update matrix

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       country:
-        description: "Country code (es, fr, at, de, se, pt, lv, ad, lt, ee)"
+        description: "Country code (es, fr, at, de, se, pt, lv, ad, lt, ee, pl, uy, gr)"
         required: false
         type: string
         default: ""
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        country: ${{ fromJson(inputs.country && format('["{0}"]', inputs.country) || '["es","fr","at","de","se","pt","lv","ad","lt","ee"]') }}
+        country: ${{ fromJson(inputs.country && format('["{0}"]', inputs.country) || '["es","fr","at","de","se","pt","lv","ad","lt","ee","pl","uy","gr"]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## Summary

Adds Poland, Uruguay and Greece to the daily-update workflow matrix. All 13 live countries now have daily updates configured.

Local dry-run verification (``legalize daily -c {code} --date 2026-04-07 --dry-run``):
- **PL** ✅ — Sejm ELI ``/changes/acts`` endpoint, clean run
- **GR** ✅ — searchetv99 ``simpleSearch``, found ``FEK-A-57-2026``
- **UY** ✅ — IMPO serial probe, clean run (slow but functional)

All three use the generic daily pipeline via ``discover_daily()`` in their ``discovery.py`` — no custom ``daily.py`` needed.

## Test plan

- [x] Local dry-run for all 3 countries
- [ ] CI green (only touches workflow YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)