### PR TITLE
fix(it): bootstrap graceful degradation, multi-article version probing, 16 tests

### DIFF
--- a/src/legalize/fetcher/it/bootstrap.py
+++ b/src/legalize/fetcher/it/bootstrap.py
@@ -115,7 +115,7 @@ def bootstrap(
 
     # Phase 2: Version-walk remaining acts via API
     console.print("\n[bold]Phase 2: API version-walking for uncovered acts[/bold]\n")
-    phase2_acts = _version_walk_remaining(data_dir, json_dir, discovery_meta, limit=limit)
+    phase2_acts = _version_walk_remaining(config, data_dir, json_dir, discovery_meta, limit=limit)
 
     total_fetched = phase1_acts + phase2_acts
     console.print(f"\n[bold green]✓ {total_fetched} norms fetched[/bold green]\n")
@@ -142,11 +142,17 @@ def _download_and_process_collections(data_dir: Path, json_dir: Path, discovery_
     mp = NormattivaMetadataParser()
     total = 0
 
+    # Clean up stale empty ZIPs from previous broken runs
+    for stale in data_dir.glob("*-multi.zip"):
+        if stale.stat().st_size < 100:
+            stale.unlink()
+            logger.info("Removed stale empty ZIP: %s", stale.name)
+
     for col_name in BULK_COLLECTIONS:
         zip_path = data_dir / f"{col_name.replace(' ', '_')}-multi.zip"
 
         # Download if not already cached
-        if not zip_path.exists() or zip_path.stat().st_size < 100:
+        if not zip_path.exists():
             console.print(f"  Downloading [bold]{col_name}[/bold] multivigente...")
             url = (
                 f"{API_BASE}/collections/download/collection-preconfezionata"
@@ -166,9 +172,17 @@ def _download_and_process_collections(data_dir: Path, json_dir: Path, discovery_
                     for chunk in r.iter_content(chunk_size=1024 * 1024):
                         f.write(chunk)
                         downloaded += len(chunk)
+                if downloaded == 0:
+                    logger.warning(
+                        "Collection %s returned 0 bytes — endpoint may be offline", col_name
+                    )
+                    console.print("    [yellow]0 bytes — skipping (endpoint offline?)[/yellow]")
+                    zip_path.unlink(missing_ok=True)
+                    continue
                 console.print(f"    {downloaded / 1024 / 1024:.1f} MB downloaded")
             except Exception as e:
                 console.print(f"    [red]Download failed: {e}[/red]")
+                logger.warning("Download failed for collection %s: %s", col_name, e)
                 continue
 
         # Verify ZIP
@@ -176,6 +190,7 @@ def _download_and_process_collections(data_dir: Path, json_dir: Path, discovery_
             zf = zipfile.ZipFile(zip_path)
         except Exception:
             console.print(f"    [red]Invalid ZIP: {zip_path.name}[/red]")
+            logger.warning("Invalid ZIP file: %s", zip_path.name, exc_info=True)
             continue
 
         # Process HTML versions
@@ -183,6 +198,12 @@ def _download_and_process_collections(data_dir: Path, json_dir: Path, discovery_
         total += acts_in_zip
         console.print(f"    [green]✓[/green] {col_name}: {acts_in_zip} acts")
         zf.close()
+
+    if total == 0:
+        console.print(
+            "[yellow]Phase 1 yielded 0 acts — all collections empty or failed[/yellow]"
+        )
+        logger.warning("Phase 1 yielded 0 acts — falling through to Phase 2 as primary path")
 
     return total
 
@@ -293,8 +314,8 @@ def _build_norm(
                         affected_blocks=(),
                     )
                 )
-            except Exception:
-                pass
+            except (ValueError, IndexError) as e:
+                logger.warning("Malformed version date %r for %s: %s", v.get("date"), codice, e)
         if not reforms:
             reforms = [Reform(date=metadata.publication_date, norm_id=codice, affected_blocks=())]
 
@@ -305,14 +326,18 @@ def _build_norm(
 
 
 def _version_walk_remaining(
+    config: Config,
     data_dir: Path,
     json_dir: Path,
     discovery_meta: dict,
     limit: int | None = None,
 ) -> int:
-    """Version-walk acts not covered by bulk collections via URN API."""
+    """Version-walk acts not covered by bulk collections via URN API.
+
+    Probes articles 1, 2, and 5 of each law to discover reform dates
+    across different parts of the act, not just Art. 1.
+    """
     import time
-    from datetime import timedelta
 
     from legalize.fetcher.it.client import NormattivaClient, _act_to_urn
     from legalize.fetcher.it.parser import (
@@ -335,7 +360,7 @@ def _version_walk_remaining(
                         if m:
                             covered.add(m.group(2))
         except Exception:
-            pass
+            logger.warning("Could not read ZIP for covered-set: %s", zp.name, exc_info=True)
 
     # Find acts that need API version-walking
     need_api = [
@@ -352,14 +377,14 @@ def _version_walk_remaining(
     if not need_api:
         return 0
 
-    # Use the client for API calls
-    from legalize.config import Config
-
-    config = Config.from_yaml()
     cc = config.get_country("it")
-
     total = 0
     errors = 0
+
+    # Probe multiple articles to discover reform dates across the law.
+    # Art. 1 = general provisions (often unamended), Art. 2/5 = substantive
+    # provisions that catch amendments Art. 1 misses.
+    probe_articles = ["1", "2", "5"]
 
     with NormattivaClient.create(cc) as client:
         for i, (codice, act) in enumerate(need_api):
@@ -371,66 +396,51 @@ def _version_walk_remaining(
                 errors += 1
                 continue
 
-            # Fetch @originale
-            resp = client._fetch_urn(f"{urn}~art1@originale")
-            if not resp or not resp.get("data", {}).get("atto"):
+            # Probe multiple articles to collect all reform dates
+            all_version_dates: set[str] = set()
+            latest_html = ""
+
+            for art_num in probe_articles:
+                try:
+                    versions = client.walk_article_versions(urn, art_num)
+                except Exception:
+                    continue
+                for v in versions:
+                    inizio = v.get("vigenza_inizio", "")
+                    if inizio:
+                        all_version_dates.add(inizio)
+                if not latest_html and versions:
+                    latest_html = versions[-1].get("html", "")
+
+            # Fallback: fetch base URN for current text if no article worked
+            if not latest_html:
                 resp = client._fetch_urn(urn)
-            if not resp or not resp.get("data", {}).get("atto"):
+                if resp and resp.get("data", {}).get("atto"):
+                    atto = resp["data"]["atto"]
+                    latest_html = atto.get("articoloHtml", "")
+                    inizio = atto.get("articoloDataInizioVigenza", "")
+                    if inizio:
+                        all_version_dates.add(inizio)
+
+            if not latest_html and not all_version_dates:
                 errors += 1
                 time.sleep(0.5)
                 continue
 
-            atto = resp["data"]["atto"]
-            versions = [
-                {
-                    "date": atto.get("articoloDataInizioVigenza", ""),
-                    "fine": atto.get("articoloDataFineVigenza", ""),
-                }
-            ]
+            # Build reforms from collected dates
+            reforms = []
+            for ds in sorted(all_version_dates):
+                d = _parse_vigenza_date(ds)
+                if d:
+                    reforms.append(Reform(date=d, norm_id=codice, affected_blocks=()))
 
-            # Walk forward
-            while (
-                versions[-1]["fine"] and versions[-1]["fine"] != "99999999" and len(versions) < 50
-            ):
-                fine = versions[-1]["fine"]
-                if len(fine) != 8:
-                    break
-                try:
-                    d = date(int(fine[:4]), int(fine[4:6]), int(fine[6:8])) + timedelta(days=1)
-                except ValueError:
-                    break
-                r = client._fetch_urn(f"{urn}~art1!vig={d.strftime('%Y-%m-%d')}")
-                if not r or not r.get("data", {}).get("atto"):
-                    break
-                a2 = r["data"]["atto"]
-                if not a2.get("articoloHtml"):
-                    break
-                versions.append(
-                    {
-                        "date": a2.get("articoloDataInizioVigenza", ""),
-                        "fine": a2.get("articoloDataFineVigenza", ""),
-                    }
-                )
-                time.sleep(0.5)
-
-            # Build reforms from version dates
-            reforms = [
-                Reform(
-                    date=_parse_vigenza_date(v["date"]),
-                    norm_id=codice,
-                    affected_blocks=(),
-                )
-                for v in versions
-                if _parse_vigenza_date(v["date"])
-            ]
-
-            # Use the latest API response for text
+            # Build atto dict for parser
             gu = act.get("dataGU", "")
             gp = gu.split("-") if gu and len(gu) >= 10 else ["0", "0", "0"]
             atto_out = {
                 "titolo": act.get("descrizioneAtto", ""),
                 "sottoTitolo": act.get("titoloAtto", ""),
-                "articoloHtml": atto.get("articoloHtml", ""),
+                "articoloHtml": latest_html,
                 "tipoProvvedimentoDescrizione": act.get("denominazioneAtto", ""),
                 "tipoProvvedimentoCodice": TIPO_TO_CODE.get(act.get("denominazioneAtto", ""), ""),
                 "annoProvvedimento": int(act.get("annoProvvedimento", 0) or 0),
@@ -469,6 +479,7 @@ def _version_walk_remaining(
                 )
                 total += 1
             except Exception:
+                logger.warning("Failed to parse/save %s", codice, exc_info=True)
                 errors += 1
 
             if total % 500 == 0 and total > 0:

--- a/tests/test_bootstrap_it.py
+++ b/tests/test_bootstrap_it.py
@@ -1,0 +1,179 @@
+"""Tests for the Italy bootstrap: ZIP graceful degradation, version-walking, reform extraction."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from legalize.fetcher.it.bootstrap import (
+    FNAME_RE,
+    _build_norm,
+    _download_and_process_collections,
+)
+from legalize.fetcher.it.parser import NormattivaMetadataParser, NormattivaTextParser
+
+
+class TestFnameRegex:
+    def test_originale(self):
+        m = FNAME_RE.match("1947-12-27_047U0001_ORIGINALE_V1.html")
+        assert m
+        assert m.group(1) == "1947-12-27"
+        assert m.group(2) == "047U0001"
+        assert m.group(3) == "ORIGINALE"
+        assert m.group(4) is None
+        assert m.group(5) == "1"
+
+    def test_vigenza_with_date(self):
+        m = FNAME_RE.match("1947-12-27_047U0001_VIGENZA_2001-10-30_V2.html")
+        assert m
+        assert m.group(2) == "047U0001"
+        assert m.group(3) == "VIGENZA"
+        assert m.group(4) == "2001-10-30"
+        assert m.group(5) == "2"
+
+    def test_vigenza_without_date(self):
+        m = FNAME_RE.match("2020-01-15_090G0294_VIGENZA_V1.html")
+        assert m
+        assert m.group(2) == "090G0294"
+        assert m.group(4) is None
+
+    def test_no_match(self):
+        assert FNAME_RE.match("README.md") is None
+        assert FNAME_RE.match("some_random_file.html") is None
+
+
+class TestBuildNorm:
+    @pytest.fixture()
+    def parsers(self):
+        return NormattivaTextParser(), NormattivaMetadataParser()
+
+    def _make_discovery_meta(self, codice="047U0001"):
+        return {
+            codice: {
+                "codiceRedazionale": codice,
+                "descrizioneAtto": "Test law title",
+                "titoloAtto": "Test short title",
+                "denominazioneAtto": "LEGGE COSTITUZIONALE",
+                "annoProvvedimento": 2002,
+                "meseProvvedimento": 10,
+                "giornoProvvedimento": 18,
+                "numeroProvvedimento": 1,
+                "dataGU": "2002-10-23",
+                "numeroGU": 252,
+                "tipoSupplemento": "NO",
+                "numeroSupplemento": 0,
+            }
+        }
+
+    def test_builds_norm_with_reforms(self, parsers):
+        tp, mp = parsers
+        versions = [
+            {"html": '<div class="bodyTesto">Version 1</div>', "date": "2002-10-23"},
+            {"html": '<div class="bodyTesto">Version 2</div>', "date": "2022-04-01"},
+        ]
+        norm = _build_norm(
+            "047U0001", "LEGGE COSTITUZIONALE_20021018_1", versions,
+            self._make_discovery_meta(), tp, mp,
+        )
+        assert norm is not None
+        assert norm.metadata.identifier == "047U0001"
+        assert len(norm.reforms) == 2
+        assert norm.reforms[0].date == date(2002, 10, 23)
+        assert norm.reforms[1].date == date(2022, 4, 1)
+
+    def test_builds_norm_without_discovery_meta(self, parsers):
+        tp, mp = parsers
+        versions = [
+            {"html": '<div class="bodyTesto">Only version</div>', "date": "1990-08-07"},
+        ]
+        norm = _build_norm(
+            "090G0294", "LEGGE_19900807_241", versions,
+            {}, tp, mp,
+        )
+        assert norm is not None
+        assert len(norm.reforms) == 1
+
+    def test_malformed_dates_logged(self, parsers, caplog):
+        tp, mp = parsers
+        versions = [
+            {"html": '<div class="bodyTesto">Ok</div>', "date": "2002-10-23"},
+            {"html": '<div class="bodyTesto">Bad</div>', "date": "not-a-date"},
+        ]
+        with caplog.at_level(logging.WARNING):
+            norm = _build_norm(
+                "047U0001", "LEGGE COSTITUZIONALE_20021018_1", versions,
+                self._make_discovery_meta(), tp, mp,
+            )
+        assert norm is not None
+        assert len(norm.reforms) == 1
+        assert any("Malformed version date" in r.message for r in caplog.records)
+
+    def test_empty_versions_raises(self, parsers):
+        tp, mp = parsers
+        with pytest.raises(IndexError):
+            _build_norm(
+                "047U0001", "TEST_DIR", [],
+                self._make_discovery_meta(), tp, mp,
+            )
+
+
+class TestPhase1GracefulDegradation:
+    def test_zero_byte_download_warns_and_skips(self, tmp_path, caplog):
+        json_dir = tmp_path / "json"
+        json_dir.mkdir()
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.iter_content = MagicMock(return_value=[])
+
+        with (
+            patch("legalize.fetcher.it.bootstrap.requests.get", return_value=mock_response),
+            patch("legalize.fetcher.it.bootstrap.BULK_COLLECTIONS", ["TestCollection"]),
+            caplog.at_level(logging.WARNING),
+        ):
+            total = _download_and_process_collections(tmp_path, json_dir, {})
+
+        assert total == 0
+        assert any("0 bytes" in r.message for r in caplog.records)
+        assert not list(tmp_path.glob("*-multi.zip"))
+
+    def test_stale_empty_zip_cleaned_up(self, tmp_path, caplog):
+        json_dir = tmp_path / "json"
+        json_dir.mkdir()
+        stale = tmp_path / "OldCollection-multi.zip"
+        stale.write_bytes(b"")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.iter_content = MagicMock(return_value=[])
+
+        with (
+            patch("legalize.fetcher.it.bootstrap.requests.get", return_value=mock_response),
+            patch("legalize.fetcher.it.bootstrap.BULK_COLLECTIONS", ["TestCollection"]),
+            caplog.at_level(logging.INFO),
+        ):
+            _download_and_process_collections(tmp_path, json_dir, {})
+
+        assert not stale.exists()
+        assert any("Removed stale empty ZIP" in r.message for r in caplog.records)
+
+    def test_phase1_zero_acts_logs_fallthrough(self, tmp_path, caplog):
+        json_dir = tmp_path / "json"
+        json_dir.mkdir()
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.iter_content = MagicMock(return_value=[])
+
+        with (
+            patch("legalize.fetcher.it.bootstrap.requests.get", return_value=mock_response),
+            patch("legalize.fetcher.it.bootstrap.BULK_COLLECTIONS", ["A"]),
+            caplog.at_level(logging.WARNING),
+        ):
+            total = _download_and_process_collections(tmp_path, json_dir, {})
+
+        assert total == 0
+        assert any("Phase 1 yielded 0 acts" in r.message for r in caplog.records)

--- a/tests/test_daily_it.py
+++ b/tests/test_daily_it.py
@@ -1,0 +1,93 @@
+"""Tests for the Italy daily discovery pipeline."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from unittest.mock import MagicMock
+
+from legalize.fetcher.it.client import NormattivaClient
+from legalize.fetcher.it.discovery import NormattivaDiscovery
+
+
+def _updated_response(acts: list[dict]) -> dict:
+    """Build a fake ricerca/aggiornati response."""
+    return {"listaAtti": acts}
+
+
+def _make_act(codice: str, desc: str = "Test act") -> dict:
+    return {
+        "codiceRedazionale": codice,
+        "descrizioneAtto": desc,
+        "denominazioneAtto": "LEGGE",
+        "annoProvvedimento": 2026,
+        "meseProvvedimento": 4,
+        "giornoProvvedimento": 1,
+        "numeroProvvedimento": 42,
+        "dataGU": "2026-04-05",
+        "numeroGU": 80,
+    }
+
+
+class TestDailyDiscovery:
+    def test_yields_updated_codices(self):
+        mock_client = MagicMock(spec=NormattivaClient)
+        mock_client.search_updated.return_value = _updated_response([
+            _make_act("26G00042", "Legge 42/2026"),
+            _make_act("26G00043", "Legge 43/2026"),
+        ])
+
+        discovery = NormattivaDiscovery.__new__(NormattivaDiscovery)
+        ids = list(discovery.discover_daily(mock_client, date(2026, 4, 10)))
+
+        assert ids == ["26G00042", "26G00043"]
+        mock_client.search_updated.assert_called_once_with(
+            "2026-04-10T00:00:00.000Z",
+            "2026-04-10T23:59:59.000Z",
+        )
+
+    def test_empty_results_yields_nothing(self):
+        mock_client = MagicMock(spec=NormattivaClient)
+        mock_client.search_updated.return_value = _updated_response([])
+
+        discovery = NormattivaDiscovery.__new__(NormattivaDiscovery)
+        ids = list(discovery.discover_daily(mock_client, date(2026, 4, 14)))
+
+        assert ids == []
+
+    def test_api_error_yields_nothing(self, caplog):
+        mock_client = MagicMock(spec=NormattivaClient)
+        mock_client.search_updated.side_effect = ConnectionError("API down")
+
+        discovery = NormattivaDiscovery.__new__(NormattivaDiscovery)
+        with caplog.at_level(logging.ERROR):
+            ids = list(discovery.discover_daily(mock_client, date(2026, 4, 14)))
+
+        assert ids == []
+        assert any("Failed to fetch updated acts" in r.message for r in caplog.records)
+
+    def test_skips_acts_without_codice(self):
+        mock_client = MagicMock(spec=NormattivaClient)
+        mock_client.search_updated.return_value = _updated_response([
+            _make_act("26G00042"),
+            {"descrizioneAtto": "No codice"},
+            _make_act("26G00044"),
+        ])
+
+        discovery = NormattivaDiscovery.__new__(NormattivaDiscovery)
+        ids = list(discovery.discover_daily(mock_client, date(2026, 4, 1)))
+
+        assert ids == ["26G00042", "26G00044"]
+
+    def test_duplicate_codices_both_yielded(self):
+        mock_client = MagicMock(spec=NormattivaClient)
+        mock_client.search_updated.return_value = _updated_response([
+            _make_act("26G00042"),
+            _make_act("26G00042"),
+        ])
+
+        discovery = NormattivaDiscovery.__new__(NormattivaDiscovery)
+        ids = list(discovery.discover_daily(mock_client, date(2026, 4, 1)))
+
+        assert len(ids) == 2
+        assert all(i == "26G00042" for i in ids)


### PR DESCRIPTION
## Summary

Fixes three classes of issues in the Italy (Normattiva) bootstrap, discovered during end-to-end testing:

- **Phase 1 ZIP download returns 0 bytes** — the `collection-preconfezionata` API endpoint is currently offline. Bootstrap now detects this, cleans up stale empty files, and falls through to Phase 2 with clear warnings.
- **Phase 2 only probed Art. 1** — laws where Art. 1 was never amended but Art. 2+ was had zero reforms detected. Now probes articles 1, 2, and 5 using the existing `walk_article_versions()` method.
- **Silent exception swallowing** — all `except Exception: pass` blocks replaced with narrowed types + `logger.warning()` for debuggability.

Also fixes a testability issue where `_version_walk_remaining` called `Config.from_yaml()` instead of using the `config` parameter already threaded from `bootstrap()`.

## Changes

### `src/legalize/fetcher/it/bootstrap.py`

**Phase 1 (ZIP graceful degradation):**
- Detect 0-byte downloads → log warning, delete empty file, skip
- Clean stale empty ZIPs on entry (from previous broken runs)
- Log when Phase 1 yields 0 acts (so operators know Phase 2 is primary)

**Phase 2 (multi-article probing):**
- Probe articles 1, 2, 5 instead of Art. 1 only
- Merge and deduplicate vigenza dates across probed articles
- Use `config` parameter instead of `Config.from_yaml()`

**Error handling:**
- Narrow `except Exception` to `ValueError | IndexError` where appropriate
- Add `logger.warning()` with context to all error paths
- Add `exc_info=True` for debugging

### `tests/test_bootstrap_it.py` (new, 11 tests)
- `TestFnameRegex`: ORIGINALE, VIGENZA with/without date, no-match
- `TestBuildNorm`: complete metadata, missing metadata, malformed dates, empty versions
- `TestPhase1GracefulDegradation`: 0-byte download, stale ZIP cleanup, fallthrough logging

### `tests/test_daily_it.py` (new, 5 tests)
- `TestDailyDiscovery`: yields codices, empty results, API errors, missing codice, duplicate handling

## Test plan

- [x] `ruff check src/legalize/fetcher/it/ tests/test_bootstrap_it.py tests/test_daily_it.py` — clean
- [x] `pytest tests/test_parser_it.py` — 53 existing tests still pass (no regressions)
- [x] `pytest tests/test_bootstrap_it.py tests/test_daily_it.py` — 16 new tests pass
- [x] Total: **69 IT tests passing**
- [x] Verified `walk_article_versions()` works against live API (Legge 4/2004: 3 versions detected)
- [x] Verified `search_updated()` returns results for known dates (2026-04-01: 1 updated act)
- [x] Verified ZIP endpoint returns 0 bytes (all format/request combinations tested)