### PR TITLE
feat(committer): switch commit message labels from Spanish to English

### DIFF
--- a/src/legalize/committer/message.py
+++ b/src/legalize/committer/message.py
@@ -3,11 +3,11 @@
 Generic multi-country format:
     [type] Title — affected articles
 
-    Norma: BOE-A-1978-31229
-    Disposición: BOE-A-2024-3099
-    Fecha: 2024-02-17
-    URL: https://www.boe.es/...
-    Artículos afectados: Artículo 49
+    Norm: BOE-A-1978-31229
+    Disposition: BOE-A-2024-3099
+    Date: 2024-02-17
+    Source: https://www.boe.es/...
+    Affected articles: art. 49
 
     Source-Id: BOE-A-2024-3099
     Source-Date: 2024-02-17
@@ -84,16 +84,16 @@ def _build_subject(
 ) -> str:
     """Build the first line of the commit message.
 
-    [reforma] Constitución Española — art. 49
+    [reform] Constitución Española — art. 49
     """
     prefix = f"[{commit_type.value}]"
     title = metadata.short_title
 
     if commit_type == CommitType.BOOTSTRAP:
-        return f"{prefix} {title} — versión original {reform.date.year}"
+        return f"{prefix} {title} — original version {reform.date.year}"
 
     if commit_type == CommitType.FIX_PIPELINE:
-        return f"{prefix} Regenerar {title}"
+        return f"{prefix} Regenerate {title}"
 
     if affected:
         arts_brief = _abbreviate_articles(affected)
@@ -114,28 +114,28 @@ def _build_body(
 
     if commit_type == CommitType.BOOTSTRAP:
         return (
-            f"Publicación original de {metadata.short_title}.\n"
+            f"Original publication of {metadata.short_title}.\n"
             f"\n"
-            f"Norma: {metadata.identifier}\n"
-            f"Fecha: {date_str}\n"
-            f"Fuente: {metadata.source}"
+            f"Norm: {metadata.identifier}\n"
+            f"Date: {date_str}\n"
+            f"Source: {metadata.source}"
         )
 
     return (
-        f"Norma: {metadata.identifier}\n"
-        f"Disposición: {reform.norm_id}\n"
-        f"Fecha: {date_str}\n"
-        f"Fuente: {metadata.source}\n"
+        f"Norm: {metadata.identifier}\n"
+        f"Disposition: {reform.norm_id}\n"
+        f"Date: {date_str}\n"
+        f"Source: {metadata.source}\n"
         f"\n"
-        f"Artículos afectados: {affected_str}"
+        f"Affected articles: {affected_str}"
     )
 
 
 def _abbreviate_articles(articles: list[str]) -> str:
     """Abbreviate list of articles for the commit subject.
 
-    ['Artículo 49'] → 'art. 49'
-    ['Artículo 13', 'Artículo 14'] → 'arts. 13, 14'
+    ['Article 49'] → 'art. 49'
+    ['Article 13', 'Article 14'] → 'arts. 13, 14'
     """
     nums = []
     for art in articles:
@@ -153,7 +153,7 @@ def _abbreviate_articles(articles: list[str]) -> str:
         return f"arts. {', '.join(nums)}"
 
     shown = ", ".join(nums[:3])
-    return f"arts. {shown} y {len(nums) - 3} más"
+    return f"arts. {shown} and {len(nums) - 3} more"
 
 
 def _get_affected_articles(reform: Reform, blocks: list[Block] | tuple[Block, ...]) -> list[str]:


### PR DESCRIPTION
Switch the 10 hardcoded Spanish strings in `committer/message.py` to English equivalents. CommitType enum values, frontmatter keys, and git trailers were already English – these body labels were the last holdout.

Follows up on #49, which noted: *"Commit message body currently in Spanish (template default) — migrate to English per-country templates in a separate PR affecting all countries."*

This PR goes hand-in-hand with https://github.com/legalize-dev/legalize/pull/14.

### What changed

Single file: `src/legalize/committer/message.py`. Four private functions, string literals only.

| Function | Spanish | English |
| :--- | :--- | :--- |
| `_build_subject()` | `versión original {year}` | `original version {year}` |
| `_build_subject()` | `Regenerar {title}` | `Regenerate {title}` |
| `_build_body()` | `Publicación original de {title}.` | `Original publication of {title}.` |
| `_build_body()` | `Norma:` | `Norm:` |
| `_build_body()` | `Disposición:` | `Disposition:` |
| `_build_body()` | `Fecha:` | `Date:` |
| `_build_body()` | `Fuente:` | `Source:` |
| `_build_body()` | `Artículos afectados:` | `Affected articles:` |
| `_abbreviate_articles()` | `y {n} más` | `and {n} more` |

`art.` / `arts.` kept as-is – universally understood abbreviation.

### Transition

Existing commits in all 32 country repos are immutable git history – unchanged. New commits from daily updates will use English labels. This creates a visible transition in `git log`, same as the earlier CommitType migration from `[reforma]` to `[reform]`.

### Testing

Full test suite passes: 1,616 passed, 27 skipped. No test asserts on the Spanish label text – they check trailers (`Source-Id:`, `Norm-Id:`), dates, and commit counts.