### PR TITLE
fix(committer): make FastImporter additive on existing branches

### DIFF
--- a/src/legalize/committer/git_ops.py
+++ b/src/legalize/committer/git_ops.py
@@ -241,9 +241,29 @@ class FastImporter:
         self._commit_count: int = 0
         # Track current tree state: rel_path -> mark number
         self._tree: dict[str, int] = {}
+        # Existing refs/heads/main tip captured at enter-time. When set, the
+        # first emitted commit references it as its parent so we extend
+        # history instead of producing an orphan that fast-import refuses to
+        # fast-forward onto main.
+        self._initial_parent: str | None = None
 
     def __enter__(self) -> FastImporter:
         self._ensure_repo()
+        try:
+            self._initial_parent = (
+                subprocess.run(
+                    ["git", "rev-parse", "--verify", "refs/heads/main"],
+                    cwd=self._path,
+                    capture_output=True,
+                    check=True,
+                    env=_clean_git_env(),
+                )
+                .stdout.decode()
+                .strip()
+                or None
+            )
+        except subprocess.CalledProcessError:
+            self._initial_parent = None
         self._proc = subprocess.Popen(
             ["git", "fast-import", "--quiet"],
             cwd=self._path,
@@ -323,9 +343,13 @@ class FastImporter:
         self._write(message_bytes)
         self._write(b"\n")
 
-        # Reference parent (all commits after the first)
+        # Reference parent. After the first commit we chain by mark; for the
+        # first commit we anchor on the pre-existing branch tip when one
+        # exists, so this stream extends history instead of orphaning it.
         if self._commit_count > 0:
             self._write(f"from :{commit_mark - 2}\n".encode())
+        elif self._initial_parent is not None:
+            self._write(f"from {self._initial_parent}\n".encode())
 
         # File modification
         self._write(f"M 100644 :{blob_mark} {rel_path}\n".encode())
@@ -362,9 +386,16 @@ class FastImporter:
             )
 
     def _checkout(self) -> None:
-        """Checkout main to populate the working tree after fast-import."""
+        """Sync index + working tree with the new main tip after fast-import.
+
+        ``git fast-import`` advances refs but never touches the index or
+        the working tree. A plain ``git checkout main`` is a no-op when
+        HEAD already points to main, so we reset the whole tree state
+        atomically — this works for both empty bootstraps and additive
+        runs on top of an existing branch.
+        """
         subprocess.run(
-            ["git", "checkout", "main"],
+            ["git", "reset", "--hard", "refs/heads/main"],
             cwd=self._path,
             capture_output=True,
             check=True,

--- a/tests/test_pipeline_bootstrap.py
+++ b/tests/test_pipeline_bootstrap.py
@@ -274,3 +274,73 @@ class TestFastImporter:
 
         md_path = Path(cc.repo_path) / "es" / "BOE-A-1978-31229.md"
         assert md_path.exists()
+
+    def test_seeds_from_existing_main_tip(self, bootstrap_config, constitucion_metadata):
+        """FastImporter should extend an existing branch instead of orphaning it.
+
+        Regression: without an explicit ``from`` clause on the first commit,
+        git fast-import refuses to fast-forward refs/heads/main onto an
+        unrelated tip and the imported commits become unreachable.
+        """
+        xml_path = FIXTURES_DIR / "constitucion-sample.xml"
+        xml_bytes = xml_path.read_bytes()
+        blocks = parse_text_xml(xml_bytes)
+        reforms = extract_reforms(blocks)
+
+        from legalize.transformer.markdown import render_norm_at_date
+
+        cc = bootstrap_config.get_country("es")
+
+        # Seed the repo with a baseline commit on refs/heads/main.
+        repo = Path(cc.repo_path)
+        repo.mkdir(parents=True, exist_ok=True)
+        for cmd in (
+            ["git", "init", "-q", "-b", "main"],
+            ["git", "config", "user.email", "test@test"],
+            ["git", "config", "user.name", "test"],
+        ):
+            subprocess.run(cmd, cwd=repo, check=True, capture_output=True)
+        (repo / "baseline.md").write_text("baseline\n")
+        subprocess.run(["git", "add", "baseline.md"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "baseline"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        baseline_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        with FastImporter(cc.repo_path, "Test", "test@test.com") as fi:
+            for i, reform in enumerate(reforms):
+                is_first = i == 0
+                commit_type = CommitType.BOOTSTRAP if is_first else CommitType.REFORM
+                markdown = render_norm_at_date(
+                    constitucion_metadata, blocks, reform.date, include_all=is_first
+                )
+                file_path = norm_to_filepath(constitucion_metadata)
+                info = build_commit_info(
+                    commit_type, constitucion_metadata, reform, blocks, file_path, markdown
+                )
+                fi.commit(file_path, markdown, info)
+
+        # Total commits = baseline + reforms; baseline must still be reachable.
+        log = subprocess.run(
+            ["git", "rev-list", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.split()
+        assert len(log) == fi.commit_count + 1
+        assert baseline_sha in log
+        assert log[-1] == baseline_sha  # oldest = baseline
+
+        # The baseline file survives alongside the new norm file.
+        assert (repo / "baseline.md").exists()
+        assert (repo / "es" / "BOE-A-1978-31229.md").exists()


### PR DESCRIPTION
Make `FastImporter` extend an existing branch instead of orphaning it.

`git fast-import` advances refs but never touches the index or working tree, and the follow-up `git checkout main` is a no-op when HEAD already points there. Two consequences when running on a non-empty repo:

1. The first emitted commit had no `from` clause, so fast-import refused to fast-forward `refs/heads/main` onto an unrelated tip — the new commits became unreachable orphans.
2. Even with a parent set, the working tree stayed at the pre-import state and `git status` listed every file in the new tip as deleted.

Fix:

- Capture `refs/heads/main` at `__enter__` time. The first commit emits `from <captured-sha>` so the new chain extends history.
- Replace the post-import `git checkout main` with `git reset --hard refs/heads/main` so HEAD/index/working tree converge atomically.

Empty-repo bootstraps are unaffected: there's no parent to capture (skipped), and `reset --hard` works the same as `checkout main` once the ref exists.

Adds a regression test (`test_seeds_from_existing_main_tip`) that seeds a baseline commit, runs FastImporter, and asserts the baseline survives + working tree reflects HEAD.

Discovered while building the UK statutory-instrument bulk bootstrap (separate work, not part of this PR), where ~150K SI commits need to land on top of the existing 38K Acts in `legalize-dev/legalize-uk`. The fix is country-agnostic, so opening it standalone.