### PR TITLE
docs(maintainers): use English commit type names

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -64,8 +64,8 @@ You do not own:
   project lead.
 - **The output format.** Filenames (= official ID), commit author
   (`Legalize <legalize@legalize.dev>`), commit trailers (`Source-Id`,
-  `Source-Date`, `Norm-Id`), commit types (`[bootstrap]`, `[reforma]`,
-  `[nueva]`, `[derogacion]`, `[correccion]`, `[fix-pipeline]`), and the
+  `Source-Date`, `Norm-Id`), commit types (`[bootstrap]`, `[reform]`,
+  `[new]`, `[repeal]`, `[correction]`, `[fix-pipeline]`), and the
   FLAT directory layout are locked. Changing any of this requires
   regenerating every country's history. Don't touch them without
   explicit approval.


### PR DESCRIPTION
Align the locked-format list with the actual `CommitType` enum and SPEC.md v0.2: `reforma` → `reform`, `nueva` → `new`, `derogacion` → `repeal`, `correccion` → `correction`. `[bootstrap]` and `[fix-pipeline]` are already English in the source.

The Spanish names predate PR #52 (committer i18n) and PR #14 (SPEC.md v0.2 bump). The doc was added in d44c5d1 with the old strings; spotted while reviewing the new MAINTAINERS.md as the incoming UK maintainer.