### PR TITLE
fix(uk): parse SI preamble, signatures, notes, footnotes, and bare-P bodies

### DIFF
--- a/src/legalize/fetcher/uk/parser.py
+++ b/src/legalize/fetcher/uk/parser.py
@@ -214,6 +214,16 @@ def _inline_text(element: etree._Element) -> str:
             # amendment history is captured in the reform timeline, not in
             # visual decoration.
             parts.append(_inline_text(child))
+        elif localname == "FootnoteRef":
+            # Emit a GitHub-style footnote marker so the body text links
+            # back to the corresponding definition in the document-level
+            # <Footnotes> block (rendered as `[^id]: …` by
+            # ``_render_footnotes``). Without this branch the body would
+            # silently drop the reference and leave the definitions
+            # dangling at the end of the document.
+            ref = child.get("Ref")
+            if ref:
+                parts.append(f"[^{ref}]")
         elif localname in ("Figure", "Image"):
             parts.append("[image omitted]")
         else:
@@ -795,7 +805,7 @@ def _walk_recursive(
 def _render_plain_paragraph(p_el: etree._Element, builder: _BlockBuilder) -> None:
     """Render a body-level ``<P>`` element.
 
-    Two shapes occur in practice:
+    Three shapes occur in practice:
 
     1. **Prose paragraph** — ``<P><Text>…</Text></P>``. Common in
        schedule narrative (HRA Protocols nested in schedule containers
@@ -808,21 +818,37 @@ def _render_plain_paragraph(p_el: etree._Element, builder: _BlockBuilder) -> Non
        resolutions like uksi-2012-1866, single-purpose block-amender
        SIs). The ``<P>`` itself carries no own prose; its children are
        the substantive content.
+    3. **Mixed lead-in + envelope** —
+       ``<P><Text>lead-in</Text><P2>…</P2><P2>…</P2></P>``. Common in
+       SI explanatory notes whose first sentence introduces the fee
+       table that follows (uksi-1996-690 is the canonical case).
 
-    Try (1) first; if it produces nothing, fall back to walking the
-    children with the same inline renderer used inside ``<P1para>``.
-    That renderer already knows ``P{N}``, ``BlockAmendment``,
-    ``Tabular``, ``Formula``, and lists — so the SI case picks up the
-    nested regulations / quoted amendment for free without changing
-    behaviour for the prose case.
+    Decide structurally per-``<P>``: if any non-``<Text>`` content
+    child is present (``P{N}``, ``P{N}group``, ``BlockAmendment``,
+    ``Tabular``, ``Formula``, list, ``BlockText``, …), walk all
+    children in document order via the same inline renderer used
+    inside ``<P1para>``. Otherwise emit only ``<Text>`` children.
+
+    The structural decision is local to this element — it must not
+    consult ``builder.paragraphs`` because the builder is shared across
+    every sibling ``<P>`` in containers like ``<ExplanatoryNotes>``.
     """
+    has_structural = False
+    for child in p_el:
+        if not isinstance(child.tag, str):
+            continue
+        local = etree.QName(child.tag).localname
+        if local not in ("Text", "Pnumber"):
+            has_structural = True
+            break
+    if has_structural:
+        for child in p_el:
+            _render_inline_child(child, builder, depth=0)
+        return
     for text_el in p_el.findall("leg:Text", NS):
         piece = _clean_text(_inline_text(text_el))
         if piece:
             builder.add("parrafo", piece)
-    if builder.paragraphs:
-        return
-    _render_p_body(p_el, builder, depth=0)
 
 
 def _synthesize_block_id(p1: etree._Element) -> str:

--- a/src/legalize/fetcher/uk/parser.py
+++ b/src/legalize/fetcher/uk/parser.py
@@ -407,9 +407,21 @@ def _gather_section_blocks(
         if long_title is not None:
             for para in long_title.findall("leg:Para", NS):
                 builder.add("parrafo", _inline_text(para))
+        # SI prelim dates: MadeDate / LaidDate / ComingIntoForce. Primary
+        # legislation has no equivalents, so this loop is a no-op for ukpga.
+        for date_tag in ("MadeDate", "LaidDate", "ComingIntoForce"):
+            for el in prelims.findall(f"leg:{date_tag}", NS):
+                _emit_si_date_paragraph(el, builder)
         preamble = prelims.find(".//leg:Preamble", NS)
         if preamble is not None:
             for para in preamble.findall(".//leg:Para", NS):
+                builder.add("parrafo", _inline_text(para))
+        # SIs use <SecondaryPreamble> wrapping <EnactingText> / <Resolution>
+        # rather than the primary-legislation <Preamble> element. Without
+        # this lookup, SI preambles silently disappear from the rendered MD.
+        sec_preamble = prelims.find(".//leg:SecondaryPreamble", NS)
+        if sec_preamble is not None:
+            for para in sec_preamble.findall(".//leg:Para", NS):
                 builder.add("parrafo", _inline_text(para))
         intro = prelims.find(".//leg:IntroductoryText", NS)
         if intro is not None:
@@ -463,14 +475,60 @@ def _gather_section_blocks(
                     ),
                 )
 
-    # 4. Commentaries — editorial notes attached to provisions. Render as a
+    # 4. Signed section — SIs end with one or more Signatory blocks
+    # ("Made by the Secretary of State for X on Y"). Sits inside <Body>
+    # for SIs, but the body walker doesn't know its shape, so render it
+    # separately. No-op for primary legislation (Acts don't use this).
+    signed_block = _render_signed_section(root)
+    if signed_block is not None:
+        results.append(signed_block)
+
+    # 5. Commentaries — editorial notes attached to provisions. Render as a
     # footnote block at the end of the document so the text has context but
     # the main body stays clean.
     commentaries_block = _render_commentaries(root)
     if commentaries_block is not None:
         results.append(commentaries_block)
 
+    # 6. Explanatory notes — SI prose appended after the operative
+    # provisions ("(This note is not part of the Regulations)"). Sibling
+    # of <Body> inside <Secondary>; missed by the body walker. No-op for
+    # primary legislation.
+    notes_block = _render_explanatory_notes(root)
+    if notes_block is not None:
+        results.append(notes_block)
+
+    # 7. Footnotes — document-level citation references. Both primary
+    # and secondary legislation put them in a top-level <Footnotes>
+    # sibling of <Primary>/<Secondary>. Without this block the
+    # <FootnoteRef> markers in the body have nothing to resolve to.
+    footnotes_block = _render_footnotes(root)
+    if footnotes_block is not None:
+        results.append(footnotes_block)
+
     return results
+
+
+def _emit_si_date_paragraph(date_el: etree._Element, builder: _BlockBuilder) -> None:
+    """Render an SI prelim date element (MadeDate / LaidDate / ComingIntoForce).
+
+    Two shapes occur:
+
+    * ``<X><Text>Label</Text><DateText>2nd Jan 2024</DateText></X>`` —
+      label plus formatted date.
+    * ``<X><Text>Coming into force in accordance with…</Text></X>`` —
+      conditional commencement, no DateText. The Text *is* the value.
+    """
+    label_el = date_el.find("leg:Text", NS)
+    date_text_el = date_el.find("leg:DateText", NS)
+    label = _clean_text(label_el.text) if label_el is not None and label_el.text else ""
+    date_text = (
+        _clean_text(date_text_el.text) if date_text_el is not None and date_text_el.text else ""
+    )
+    if label and date_text:
+        builder.add("parrafo", f"{label}: {date_text}")
+    elif label:
+        builder.add("parrafo", label)
 
 
 def _schedule_heading_paragraph(sched: etree._Element) -> Paragraph | None:
@@ -522,6 +580,129 @@ def _render_commentaries(
     # Heading ahead of the footnotes.
     heading = Paragraph(css_class="h2", text="Editorial notes")
     return ("commentaries", "commentaries", "", [heading, *paragraphs], 0)
+
+
+def _render_signed_section(
+    root: etree._Element,
+) -> tuple[str, str, str, list[Paragraph], int] | None:
+    """Render the ``<SignedSection>`` of an SI as a free-standing block.
+
+    SIs end with one or more ``<Signatory>`` entries naming who made the
+    instrument (Minister, Lord Commissioner, …) and when. Each Signatory
+    optionally carries a lead-in ``<Para>`` (e.g., "We consent,") plus
+    one or more ``<Signee>`` records with PersonName / JobTitle /
+    Department / DateSigned. Without this rendering, the legal
+    provenance is silently dropped — the body walker doesn't recognise
+    the SignedSection shape and produces no output from it.
+    """
+    signed = root.find(".//leg:SignedSection", NS)
+    if signed is None:
+        return None
+    paragraphs: list[Paragraph] = []
+    for sig in signed.findall("leg:Signatory", NS):
+        for para in sig.findall("leg:Para", NS):
+            text = _clean_text(_inline_text(para))
+            if text:
+                paragraphs.append(Paragraph(css_class="parrafo", text=text))
+        for signee in sig.findall("leg:Signee", NS):
+            pieces: list[str] = []
+            for tag in ("PersonName", "JobTitle", "Department"):
+                for el in signee.findall(f"leg:{tag}", NS):
+                    text = _clean_text(_inline_text(el))
+                    if text:
+                        pieces.append(text)
+            date_el = signee.find("leg:DateSigned", NS)
+            if date_el is not None:
+                date_text_el = date_el.find("leg:DateText", NS)
+                if date_text_el is not None and date_text_el.text:
+                    pieces.append(_clean_text(date_text_el.text))
+            if pieces:
+                paragraphs.append(Paragraph(css_class="parrafo", text=" — ".join(pieces)))
+    if not paragraphs:
+        return None
+    heading = Paragraph(css_class="h2", text="Signed")
+    return ("signed-section", "signatory", "", [heading, *paragraphs], 0)
+
+
+def _render_explanatory_notes(
+    root: etree._Element,
+) -> tuple[str, str, str, list[Paragraph], int] | None:
+    """Render the ``<ExplanatoryNotes>`` element of an SI as a block.
+
+    SIs publish a plain-English summary of what the regulations do,
+    prefixed by the disclaimer "(This note is not part of the
+    Regulations)" inside a ``<Comment>`` element. The notes sit as a
+    sibling of ``<Body>`` inside ``<Secondary>`` so the body walker
+    never sees them. Capture the comment + the substantive body of the
+    notes (``<P>`` / ``<P2>`` children) as a dedicated block so the
+    editorial summary survives in the rendered Markdown.
+    """
+    notes = root.find(".//leg:ExplanatoryNotes", NS)
+    if notes is None:
+        return None
+    builder = _BlockBuilder(block_id="explanatory-notes", block_type="explanatory-notes", title="")
+    # Disclaimer comment(s) first so the "(not part of the Regulations)"
+    # warning lands at the top of the rendered note.
+    for comment in notes.findall("leg:Comment", NS):
+        for para in comment.findall("leg:Para", NS):
+            text = _clean_text(_inline_text(para))
+            if text:
+                builder.add("parrafo", text)
+    for child in notes:
+        local = etree.QName(child.tag).localname if isinstance(child.tag, str) else ""
+        if not local or local == "Comment":
+            continue
+        if local == "P":
+            _render_plain_paragraph(child, builder)
+        elif local in ("P1", "P2", "P3", "P4", "P5"):
+            _render_inline_child(child, builder, depth=0)
+        else:
+            text = _clean_text(_inline_text(child))
+            if text:
+                builder.add("parrafo", text)
+    if not builder.paragraphs:
+        return None
+    heading = Paragraph(css_class="h2", text="Explanatory note")
+    return (
+        "explanatory-notes",
+        "explanatory-notes",
+        "",
+        [heading, *builder.paragraphs],
+        builder.images_dropped,
+    )
+
+
+def _render_footnotes(
+    root: etree._Element,
+) -> tuple[str, str, str, list[Paragraph], int] | None:
+    """Render the document-level ``<Footnotes>`` as a footnote block.
+
+    Both primary legislation and SIs put citation references in a
+    top-level ``<Footnotes>`` sibling of ``<Primary>`` / ``<Secondary>``.
+    Each ``<Footnote id="…">`` holds a ``<FootnoteText>`` with one or
+    more ``<Para><Text>`` entries. Rendered as GitHub-style footnote
+    definitions (``[^id]: text``) so MD renderers can link them back
+    to the ``<FootnoteRef Ref="…">`` markers in the body.
+    """
+    fns = root.find(".//leg:Footnotes", NS)
+    if fns is None:
+        return None
+    paragraphs: list[Paragraph] = []
+    for fn in fns.findall("leg:Footnote", NS):
+        fn_id = fn.get("id") or ""
+        body_pieces: list[str] = []
+        for text_el in fn.iter(f"{{{NS['leg']}}}Text"):
+            piece = _clean_text(_inline_text(text_el))
+            if piece:
+                body_pieces.append(piece)
+        body = " ".join(body_pieces)
+        if not body:
+            continue
+        paragraphs.append(Paragraph(css_class="parrafo", text=f"[^{fn_id}]: {body}"))
+    if not paragraphs:
+        return None
+    heading = Paragraph(css_class="h2", text="Footnotes")
+    return ("footnotes", "footnotes", "", [heading, *paragraphs], 0)
 
 
 _HEADING_CSS = {
@@ -612,11 +793,36 @@ def _walk_recursive(
 
 
 def _render_plain_paragraph(p_el: etree._Element, builder: _BlockBuilder) -> None:
-    """Render a ``<P>`` element's ``<Text>`` descendants as prose paragraphs."""
+    """Render a body-level ``<P>`` element.
+
+    Two shapes occur in practice:
+
+    1. **Prose paragraph** — ``<P><Text>…</Text></P>``. Common in
+       schedule narrative (HRA Protocols nested in schedule containers
+       are the canonical case). Render the direct ``<Text>`` children
+       as ``parrafo`` paragraphs.
+    2. **Section-like envelope** — ``<P><P2>…</P2>+</P>`` or
+       ``<P><BlockAmendment>…</BlockAmendment><AppendText>.</AppendText></P>``.
+       Common in SI bodies that omit the ``<P1>`` envelope around
+       regulations (fee amendments like uksi-1996-690, House of Commons
+       resolutions like uksi-2012-1866, single-purpose block-amender
+       SIs). The ``<P>`` itself carries no own prose; its children are
+       the substantive content.
+
+    Try (1) first; if it produces nothing, fall back to walking the
+    children with the same inline renderer used inside ``<P1para>``.
+    That renderer already knows ``P{N}``, ``BlockAmendment``,
+    ``Tabular``, ``Formula``, and lists — so the SI case picks up the
+    nested regulations / quoted amendment for free without changing
+    behaviour for the prose case.
+    """
     for text_el in p_el.findall("leg:Text", NS):
         piece = _clean_text(_inline_text(text_el))
         if piece:
             builder.add("parrafo", piece)
+    if builder.paragraphs:
+        return
+    _render_p_body(p_el, builder, depth=0)
 
 
 def _synthesize_block_id(p1: etree._Element) -> str:
@@ -788,6 +994,15 @@ def _render_inline_child(child: etree._Element, builder: _BlockBuilder, *, depth
         piece = _clean_text(_inline_text(child))
         if piece:
             builder.add("parrafo", f"[^cm]: {piece}")
+    elif local == "AppendText":
+        # Trailing connector that finishes the sentence after a sibling
+        # <BlockAmendment>/<Substitution>. Typically just "." or ",".
+        # Emit only when it carries substantive prose, not when it's
+        # pure punctuation — the amendment quote already captures the
+        # substance and a "." paragraph after it reads as noise.
+        piece = _clean_text(_inline_text(child))
+        if piece and not all(c in ".,;:()-" for c in piece):
+            builder.add("parrafo", piece)
     else:
         piece = _clean_text(_inline_text(child))
         if piece:

--- a/tests/fixtures/uk/sample-si-uksi-1996-690.xml
+++ b/tests/fixtures/uk/sample-si-uksi-1996-690.xml
@@ -1,0 +1,239 @@
+<Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690" NumberOfProvisions="0" xsi:schemaLocation="http://www.legislation.gov.uk/namespaces/legislation http://www.legislation.gov.uk/schema/legislation.xsd" SchemaVersion="1.0"><ukm:Metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ukm="http://www.legislation.gov.uk/namespaces/metadata">
+					<dc:identifier>http://www.legislation.gov.uk/uksi/1996/690/enacted</dc:identifier><dc:title>The Measuring Instruments (EEC Requirements) (Fees) (Amendment) Regulations 1996</dc:title><dc:subject>Local Government</dc:subject><dc:publisher>Queen's Printer of Acts of Parliament</dc:publisher><dc:modified>2017-05-04</dc:modified><dc:subject scheme="SIheading">FEES AND CHARGES</dc:subject>
+					<dc:description>These Regulations amend the fees payable in connection with services undertaken by the Department of Trade and Industry under the Non-Automatic Weighing Instruments (EEC Requirements) Regulations 1992 (S.I. 1992/1579) and other Regulations relating to instruments for which the Measuring Instruments (EEC Requirements) (Fees) Regulations 1993 (S.I. 1993/798) (“the 1993 Regulations”), as amended, provide.</dc:description>
+					<atom:link rel="self" href="http://www.legislation.gov.uk/uksi/1996/690/enacted/data.xml" type="application/xml"/><atom:link rel="http://www.legislation.gov.uk/def/navigation/resources" href="http://www.legislation.gov.uk/uksi/1996/690/resources" title="More Resources"/>
+					
+					
+					
+					<atom:link rel="http://www.legislation.gov.uk/def/navigation/act" href="http://www.legislation.gov.uk/uksi/1996/690/enacted" title="whole act"/><atom:link rel="http://www.legislation.gov.uk/def/navigation/introduction" href="http://www.legislation.gov.uk/uksi/1996/690/introduction/enacted" title="introduction"/><atom:link rel="http://www.legislation.gov.uk/def/navigation/signature" href="http://www.legislation.gov.uk/uksi/1996/690/signature/enacted" title="signature"/><atom:link rel="http://www.legislation.gov.uk/def/navigation/note" href="http://www.legislation.gov.uk/uksi/1996/690/note/enacted" title="note"/>
+					<atom:link rel="http://www.legislation.gov.uk/def/navigation/body" href="http://www.legislation.gov.uk/uksi/1996/690/body/enacted" title="body"/>
+					
+					
+										
+					
+					
+					<atom:link rel="alternate" type="application/rdf+xml" href="http://www.legislation.gov.uk/uksi/1996/690/enacted/data.rdf" title="RDF/XML"/><atom:link rel="alternate" type="application/akn+xml" href="http://www.legislation.gov.uk/uksi/1996/690/enacted/data.akn" title="AKN"/><atom:link rel="alternate" type="application/xhtml+xml" href="http://www.legislation.gov.uk/uksi/1996/690/enacted/data.xht" title="HTML snippet"/><atom:link rel="alternate" type="application/pdf" href="http://www.legislation.gov.uk/uksi/1996/690/enacted/data.pdf" title="PDF"/>
+					<atom:link rel="alternate" type="application/akn+xhtml" href="http://www.legislation.gov.uk/uksi/1996/690/enacted/data.html" title="HTML5 snippet"/>
+
+					
+					<atom:link rel="http://purl.org/dc/terms/tableOfContents" hreflang="en" href="http://www.legislation.gov.uk/uksi/1996/690/contents/enacted" title="Table of Contents"/>
+					
+					
+					
+					
+					<ukm:SecondaryMetadata><ukm:DocumentClassification>
+<ukm:DocumentCategory Value="secondary"/>
+<ukm:DocumentMainType Value="UnitedKingdomStatutoryInstrument"/>
+<ukm:DocumentStatus Value="final"/>
+<ukm:DocumentMinorType Value="regulation"/>
+</ukm:DocumentClassification><ukm:Year Value="1996"/><ukm:Number Value="690"/><ukm:Made Date="1996-03-07"/><ukm:Laid Date="1996-03-11" Class="UnitedKingdomParliament"/><ukm:ComingIntoForce>
+<ukm:DateTime Date="1996-04-08"/>
+</ukm:ComingIntoForce><ukm:ISBN Value="0110545397"/></ukm:SecondaryMetadata>
+					
+
+                    
+									 
+					
+					
+					<ukm:Statistics>
+									<ukm:TotalParagraphs Value="0"/>
+									<ukm:BodyParagraphs Value="0"/>
+									<ukm:ScheduleParagraphs Value="0"/>
+									<ukm:AttachmentParagraphs Value="0"/>
+									<ukm:TotalImages Value="0"/>
+								</ukm:Statistics>
+				</ukm:Metadata><Secondary>
+<SecondaryPrelims DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/introduction/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/introduction">
+<Number>1996 No. 690</Number>
+<SubjectInformation><Subject>
+<Title>FEES AND CHARGES</Title>
+</Subject>
+</SubjectInformation>
+<Title>The Measuring Instruments (<Acronym Expansion="European Economic Community">EEC</Acronym> Requirements) (Fees) (Amendment) Regulations 1996</Title>
+<MadeDate>
+<Text>Made</Text>
+<DateText>7th March 1996</DateText>
+</MadeDate>
+<LaidDate>
+<Text>Laid before Parliament</Text>
+<DateText>11th March 1996</DateText>
+</LaidDate>
+<ComingIntoForce>
+<Text>Coming into force</Text>
+<DateText>8th April 1996</DateText>
+</ComingIntoForce>
+<SecondaryPreamble>
+<EnactingText>
+<Para>
+<Text>The Secretary of State for Trade and Industry, with consent of the Treasury, in exercise of the powers conferred on him by section 56(1) and (2) of the Finance Act 1973<FootnoteRef Ref="f00001"/> and of all other powers enabling him in that behalf, hereby makes the following Regulations:</Text>
+</Para>
+</EnactingText>
+</SecondaryPreamble>
+</SecondaryPrelims>
+<Body DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/body/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/body" NumberFormat="default"><P DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/paragraph/1/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/paragraph/1" id="paragraph-1"><Text/>
+<P2 DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/regulation/1/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/regulation/1" id="regulation-1">
+<Pnumber>1</Pnumber>
+<P2para>
+<Text>These Regulations may be cited as the Measuring Instruments (EEC Requirements) (Fees) (Amendment) Regulations 1996 and shall come into force on 8th April 1996.</Text>
+</P2para>
+</P2>
+<P2 DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/regulation/2/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/regulation/2" id="regulation-2">
+<Pnumber>2</Pnumber>
+<P2para>
+<Text>The Measuring Instruments (EEC Requirements) (Fees) Regulations 1993<FootnoteRef Ref="f00002"/> are hereby amended as follows —</Text>
+<P3 DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/regulation/2/a/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/regulation/2/a" id="regulation-2-a">
+<Pnumber>a</Pnumber>
+<P3para>
+<Text>in paragraph 1(a) of Schedule 2, for “£53.00” substitute “£58.00”;</Text>
+</P3para>
+</P3>
+<P3 DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/regulation/2/b/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/regulation/2/b" id="regulation-2-b">
+<Pnumber>b</Pnumber>
+<P3para>
+<Text>in paragraph 1(a) of Schedule 3, for “£59.00” substitute “£60.00”, for “£53.00” substitute “£58.00” and for “£10.00” substitute “£11.50”;</Text>
+</P3para>
+</P3>
+<P3 DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/regulation/2/c/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/regulation/2/c" id="regulation-2-c">
+<Pnumber>c</Pnumber>
+<P3para>
+<Text>in paragraph 3 of Schedule 4, for “£66.00” substitute “£70.00”;</Text>
+</P3para>
+</P3>
+<P3 DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/regulation/2/d/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/regulation/2/d" id="regulation-2-d">
+<Pnumber>d</Pnumber>
+<P3para>
+<Text>in paragraph 1(a) of Schedules 5 and 6, for “£59.00” substitute “£60.00” and for “£53.00” substitute “£58.00”;</Text>
+</P3para>
+</P3>
+<P3 DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/regulation/2/e/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/regulation/2/e" id="regulation-2-e">
+<Pnumber>e</Pnumber>
+<P3para>
+<Text>in paragraph 1(b) of Schedules 5 and 6, for “£10.00” substitute “£11.50” and for “56.00” substitute “58.50”.</Text>
+</P3para>
+</P3>
+</P2para>
+</P2>
+</P>
+<SignedSection DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/signature/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/signature">
+<Signatory>
+<Signee>
+<PersonName>John M Taylor,</PersonName>
+<JobTitle>Parliamentary Under Secretary of State</JobTitle>
+<Department>Department of Trade and Industry</Department>
+<DateSigned Date="1996-03-05">
+<DateText>5th March 1996</DateText>
+</DateSigned>
+</Signee>
+</Signatory>
+<Signatory>
+<Para>
+<Text>We consent,</Text>
+</Para>
+<Signee>
+<PersonName>Derek Conway,</PersonName>
+<PersonName>Simon Burns,</PersonName>
+<JobTitle>Two of the Lords Commissioners of Her Majesty’s Treasury</JobTitle>
+<DateSigned Date="1996-03-07">
+<DateText>7th March 1996</DateText>
+</DateSigned>
+</Signee>
+</Signatory>
+</SignedSection>
+</Body>
+<ExplanatoryNotes DocumentURI="http://www.legislation.gov.uk/uksi/1996/690/note/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/1996/690/note">
+<Comment>
+<Para>
+<Text>(This note is not part of the Regulations)</Text>
+</Para>
+</Comment>
+<P>
+<Text>These Regulations amend the fees payable in connection with services undertaken by the Department of Trade and Industry under the Non-Automatic Weighing Instruments (EEC Requirements) Regulations 1992 (<Citation URI="http://www.legislation.gov.uk/id/uksi/1992/1579" id="c00001" Class="UnitedKingdomStatutoryInstrument" Year="1992" Number="1579">S.I. 1992/1579</Citation>) and other Regulations relating to instruments for which the Measuring Instruments (EEC Requirements) (Fees) Regulations 1993 (<Citation URI="http://www.legislation.gov.uk/id/uksi/1993/798" id="c00002" Class="UnitedKingdomStatutoryInstrument" Year="1993" Number="0798">S.I. 1993/798</Citation>) (“the <Abbreviation Expansion="Measuring Instruments (EEC Requirements) (Fees) Regulations 1993 (S.I. 1993/798)">1993 Regulations</Abbreviation>”), as amended, provide.</Text>
+</P>
+<P><Text>On the coming into force of these Regulations—</Text>
+<P2>
+<Pnumber>1</Pnumber>
+<P2para>
+<Text>the fees payable under regulations 3 and 4 of the 1993 Regulations in relation to which a rate per hour is specified in paragraph 1(a) of Schedules 2 and 3, are amended as follows —</Text>
+<P3>
+<Pnumber>a</Pnumber>
+<P3para>
+<Text>The rate for EEC initial verification of certain measuring instruments and systems becomes £58.00 per hour, (an increase from £53.00 per hour), (regulation 2(a));</Text>
+</P3para>
+</P3>
+<P3>
+<Pnumber>b</Pnumber>
+<P3para>
+<Text>the rate for EEC pattern approval becomes—</Text>
+<P4>
+<Pnumber>i</Pnumber>
+<P4para>
+<Text>for equipment test unit staff, £58.00 per hour (an increase from £53.00 per hour);</Text>
+</P4para>
+</P4>
+<P4>
+<Pnumber>ii</Pnumber>
+<P4para>
+<Text>for examination staff, £60.00 per hour (an increase from £59.00 per hour); and</Text>
+</P4para>
+</P4>
+<P4>
+<Pnumber>iii</Pnumber>
+<P4para>
+<Text>for any time during which the pattern is tested in an environmental testing chamber, £11.50 per hour (an increase from £10.00 per hour), (regulation 2(b));</Text>
+</P4para>
+</P4>
+</P3para>
+</P3>
+</P2para>
+</P2>
+<P2>
+<Pnumber>2</Pnumber>
+<P2para>
+<Text>the fees payable under regulation 5 of the 1993 Regulations in relation to which a rate per hour in specified in paragraph 3 of Schedule 4 (which relates to fees payable on the periodic inspection of approved bodies) are increased from £66.00 per hour to £70.00 per hour, (regulation 2(c));</Text>
+</P2para>
+</P2>
+<P2>
+<Pnumber>3</Pnumber>
+<P2para>
+<Text>the fees payable under regulations 6 and 7 of the 1993 Regulations in relation to which a rate per hour in specified in paragraphs 1(a) and 1(b) of Schedules 5 and 6 (which relate to the grant of an <Acronym Expansion="European Community">EC</Acronym> type-approval certificate or for EC unit verification) become—</Text>
+<P3>
+<Pnumber>a</Pnumber>
+<P3para>
+<Text>for examination staff, £60.00 per hour (an increase from £59.00 per hour);</Text>
+</P3para>
+</P3>
+<P3>
+<Pnumber>b</Pnumber>
+<P3para>
+<Text>for equipment test unit staff, £58.00 per hour (an increase from £53.00 per hour);</Text>
+</P3para>
+</P3>
+<P3>
+<Pnumber>c</Pnumber>
+<P3para>
+<Text>for any time during which the type or instrument is tested in an environmental testing chamber, £11.50 per hour (an increase from £10.00 per hour); and</Text>
+</P3para>
+</P3>
+<P3>
+<Pnumber>d</Pnumber>
+<P3para>
+<Text>for any time during which the type or instrument is tested for electromagnetic compatibility, £58.50 per hour (an increase from £56.00 per hour), (regulations 2(d) and (e)).</Text>
+</P3para>
+</P3>
+</P2para>
+</P2>
+</P>
+</ExplanatoryNotes>
+</Secondary><Footnotes><Footnote id="f00001">
+<FootnoteText>
+<Para>
+<Text><Citation URI="http://www.legislation.gov.uk/id/ukpga/1973/51" id="c00003" Class="UnitedKingdomPublicGeneralAct" Year="1973" Number="0051">1973 c. 51</Citation>.</Text>
+</Para>
+</FootnoteText>
+</Footnote><Footnote id="f00002">
+<FootnoteText>
+<Para>
+<Text><Citation URI="http://www.legislation.gov.uk/id/uksi/1993/798" id="c00004" Class="UnitedKingdomStatutoryInstrument" Year="1993" Number="0798">S.I. 1993/798</Citation>, amended by S.I <Citation URI="http://www.legislation.gov.uk/id/uksi/1995/1376" id="c00005" Class="UnitedKingdomStatutoryInstrument" Year="1995" Number="1376">1995/1376</Citation>.</Text>
+</Para>
+</FootnoteText>
+</Footnote></Footnotes></Legislation>

--- a/tests/fixtures/uk/sample-si-uksi-2012-1866.xml
+++ b/tests/fixtures/uk/sample-si-uksi-2012-1866.xml
@@ -1,0 +1,109 @@
+<Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" DocumentURI="http://www.legislation.gov.uk/uksi/2012/1866/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/2012/1866" NumberOfProvisions="0" xml:lang="en" xsi:schemaLocation="http://www.legislation.gov.uk/namespaces/legislation http://www.legislation.gov.uk/schema/legislation.xsd" SchemaVersion="1.0"><ukm:Metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ukm="http://www.legislation.gov.uk/namespaces/metadata">
+					<dc:identifier>http://www.legislation.gov.uk/uksi/2012/1866/enacted</dc:identifier><dc:title>House of Commons Members’ Fund Resolution 2012</dc:title><dc:subject>UK Parliament</dc:subject><dc:language>en</dc:language><dc:publisher>King's Printer of Acts of Parliament</dc:publisher><dc:modified>2012-11-16</dc:modified><dc:subject scheme="SIheading">PARLIAMENT</dc:subject>
+					
+					<atom:link rel="self" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.xml" type="application/xml"/><atom:link rel="http://www.legislation.gov.uk/def/navigation/resources" href="http://www.legislation.gov.uk/uksi/2012/1866/resources" title="More Resources"/>
+					
+					
+					
+					<atom:link rel="http://www.legislation.gov.uk/def/navigation/act" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted" title="whole act"/><atom:link rel="http://www.legislation.gov.uk/def/navigation/introduction" href="http://www.legislation.gov.uk/uksi/2012/1866/introduction/enacted" title="introduction"/>
+					<atom:link rel="http://www.legislation.gov.uk/def/navigation/body" href="http://www.legislation.gov.uk/uksi/2012/1866/body/enacted" title="body"/>
+					
+					
+										
+					
+					
+					
+					<atom:link rel="alternate" type="application/rdf+xml" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.rdf" title="RDF/XML"/><atom:link rel="alternate" type="application/akn+xml" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.akn" title="AKN"/><atom:link rel="alternate" type="application/xhtml+xml" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.xht" title="HTML snippet"/><atom:link rel="alternate" type="text/html" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.htm" title="Website (XHTML) Default View"/><atom:link rel="alternate" type="text/csv" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.csv" title="CSV"/><atom:link rel="alternate" type="application/pdf" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.pdf" title="PDF"/>
+					<atom:link rel="alternate" type="application/akn+xhtml" href="http://www.legislation.gov.uk/uksi/2012/1866/enacted/data.html" title="HTML5 snippet"/>
+
+					<atom:link rel="alternate" href="http://www.legislation.gov.uk/uksi/2012/1866/pdfs/uksi_20121866_en.pdf" type="application/pdf" title="Original PDF"/>
+					<atom:link rel="http://purl.org/dc/terms/tableOfContents" hreflang="en" href="http://www.legislation.gov.uk/uksi/2012/1866/contents/enacted" title="Table of Contents"/>
+					
+					
+					
+					
+					<ukm:SecondaryMetadata><ukm:DocumentClassification>
+<ukm:DocumentCategory Value="secondary"/>
+<ukm:DocumentMainType Value="UnitedKingdomStatutoryInstrument"/>
+<ukm:DocumentStatus Value="final"/>
+<ukm:DocumentMinorType Value="unknown"/>
+</ukm:DocumentClassification><ukm:Year Value="2012"/><ukm:Number Value="1866"/><ukm:Made Date="2012-06-13"/><ukm:ISBN Value="9780111527214"/></ukm:SecondaryMetadata>
+					
+
+                    
+									 
+					<ukm:Alternatives><ukm:Alternative URI="http://www.legislation.gov.uk/uksi/2012/1866/pdfs/uksi_20121866_en.pdf" Date="2012-07-18" Size="36416"/></ukm:Alternatives>
+					
+					<ukm:Statistics>
+									<ukm:TotalParagraphs Value="0"/>
+									<ukm:BodyParagraphs Value="0"/>
+									<ukm:ScheduleParagraphs Value="0"/>
+									<ukm:AttachmentParagraphs Value="0"/>
+									<ukm:TotalImages Value="0"/>
+								</ukm:Statistics>
+				</ukm:Metadata><Secondary>
+<SecondaryPrelims DocumentURI="http://www.legislation.gov.uk/uksi/2012/1866/introduction/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/2012/1866/introduction">
+<Number>2012 No. 1866</Number>
+<SubjectInformation>
+<Subject>
+<Title>Parliament</Title>
+</Subject>
+</SubjectInformation>
+<Title>House of Commons Members’ Fund Resolution 2012</Title>
+<MadeDate>
+<Text>Made</Text>
+<DateText>13th June 2012</DateText>
+</MadeDate>
+<ComingIntoForce>
+<Text>Coming into force in accordance with the Resolution</Text>
+</ComingIntoForce>
+<SecondaryPreamble>
+<Resolution>
+<Para>
+<Text>
+<Emphasis>Resolved</Emphasis>, pursuant to section 3 of the House of Commons Members’ Fund Act 1948<FootnoteRef Ref="f00001"/> and section 2 of the House of Commons Members’ Fund and Parliamentary Pensions Act 1981<FootnoteRef Ref="f00002"/>, that the following shall be substituted for paragraph (6) of the Resolution of this House of 7 March 2005<FootnoteRef Ref="f00003"/> with effect from April 2012:</Text>
+</Para>
+</Resolution>
+</SecondaryPreamble>
+</SecondaryPrelims>
+<Body DocumentURI="http://www.legislation.gov.uk/uksi/2012/1866/body/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/2012/1866/body" NumberFormat="default">
+<P DocumentURI="http://www.legislation.gov.uk/uksi/2012/1866/paragraph/1/enacted" IdURI="http://www.legislation.gov.uk/id/uksi/2012/1866/paragraph/1" id="paragraph-1">
+<BlockAmendment TargetSubClass="unknown" TargetClass="unknown" Format="default" Context="unknown">
+<P2>
+<Pnumber>6</Pnumber>
+<P2para>
+<Text>the relevant percentage to be applied each April is the percentage applied for the purposes of Part I of the Pensions (Increase) Act 1971 in respect of that April</Text>
+</P2para>
+</P2>
+</BlockAmendment>
+<AppendText>.</AppendText>
+</P>
+</Body>
+</Secondary><Footnotes><Footnote id="f00001">
+<FootnoteText>
+<Para>
+<Text>
+
+
+<Citation URI="http://www.legislation.gov.uk/id/ukpga/1948/36" id="c00001" Class="UnitedKingdomPublicGeneralAct" Year="1948" Number="0036">1948 c. 36</Citation>.</Text>
+</Para>
+</FootnoteText>
+</Footnote><Footnote id="f00002">
+<FootnoteText>
+<Para>
+<Text>
+
+
+<Citation URI="http://www.legislation.gov.uk/id/ukpga/1981/7" id="c00002" Class="UnitedKingdomPublicGeneralAct" Year="1981" Number="0007">1981 c. 7</Citation>; section 2(1) has been amended by Resolution of the House of Commons.</Text>
+</Para>
+</FootnoteText>
+</Footnote><Footnote id="f00003">
+<FootnoteText>
+<Para>
+<Text>
+
+
+<Citation URI="http://www.legislation.gov.uk/id/uksi/2005/657" id="c00003" Class="UnitedKingdomStatutoryInstrument" Year="2005" Number="0657"><Acronym Expansion="Statutory Instrument">S.I.</Acronym> 2005/657</Citation>.</Text>
+</Para>
+</FootnoteText>
+</Footnote></Footnotes></Legislation>

--- a/tests/test_parser_uk.py
+++ b/tests/test_parser_uk.py
@@ -409,3 +409,101 @@ class TestSITextParser:
         assert "<Legislation" not in md
         assert "<ukm:" not in md
         assert "xmlns:" not in md
+
+    def test_uksi_1996_690_p_body_with_p2_regulations_renders(self):
+        """SI body uses ``<P><Text/><P2>regulation</P2>+</P>`` (fee amender).
+
+        Regression: before PR #1, this shape produced 0 blocks because
+        ``_render_plain_paragraph`` only read direct ``<Text>`` children of
+        ``<P>``. uksi-1996-690 has an empty ``<Text/>`` at the head and the
+        regulations live in ``<P2>`` siblings inside the same ``<P>``.
+        """
+        data = _read_fixture("sample-si-uksi-1996-690.xml")
+        blocks = UKTextParser().parse_text(data)
+        assert blocks, "0 blocks would crash the bootstrap"
+        text = " ".join(p.text for b in blocks for v in b.versions for p in v.paragraphs)
+        assert "These Regulations may be cited as" in text
+        assert "£53.00" in text and "£58.00" in text
+
+    def test_uksi_2012_1866_p_body_with_block_amendment_renders(self):
+        """SI body is ``<P><BlockAmendment>…</BlockAmendment><AppendText>.</AppendText></P>``.
+
+        Regression: before PR #1, this shape produced 0 blocks. The
+        BlockAmendment is the entire substantive content of the
+        resolution; ``AppendText`` is just a trailing "." that we now
+        suppress.
+        """
+        data = _read_fixture("sample-si-uksi-2012-1866.xml")
+        blocks = UKTextParser().parse_text(data)
+        assert blocks, "0 blocks would crash the bootstrap"
+        text = " ".join(p.text for b in blocks for v in b.versions for p in v.paragraphs)
+        assert "relevant percentage to be applied each April" in text
+        # The trailing "." AppendText must not surface as its own paragraph.
+        for b in blocks:
+            for v in b.versions:
+                for p in v.paragraphs:
+                    assert p.text.strip() != ".", f"orphan AppendText '.' in block {b.id}"
+
+    def test_si_secondary_preamble_renders_in_preamble_block(self):
+        """SIs use ``<SecondaryPreamble>`` not ``<Preamble>``.
+
+        The enacting text / resolution must end up in the preamble block.
+        """
+        data = _read_fixture("sample-si-uksi-1996-690.xml")
+        blocks = UKTextParser().parse_text(data)
+        preamble = next((b for b in blocks if b.block_type == "preamble"), None)
+        assert preamble is not None
+        text = " ".join(p.text for v in preamble.versions for p in v.paragraphs)
+        assert "Secretary of State for Trade and Industry" in text
+        # SI prelim dates land in the preamble.
+        assert "Made: 7th March 1996" in text
+        assert "Laid before Parliament: 11th March 1996" in text
+        assert "Coming into force: 8th April 1996" in text
+
+    def test_si_signed_section_emits_dedicated_block(self):
+        """`<SignedSection>` becomes a separate block with signee details."""
+        data = _read_fixture("sample-si-uksi-1996-690.xml")
+        blocks = UKTextParser().parse_text(data)
+        signed = next((b for b in blocks if b.block_type == "signatory"), None)
+        assert signed is not None
+        text = " ".join(p.text for v in signed.versions for p in v.paragraphs)
+        assert "John M Taylor" in text
+        assert "Parliamentary Under Secretary of State" in text
+        assert "5th March 1996" in text
+        # Multi-signatory: the Treasury lead-in and the Lords Commissioners.
+        assert "We consent," in text
+        assert "Derek Conway" in text
+
+    def test_si_explanatory_notes_emit_dedicated_block(self):
+        """`<ExplanatoryNotes>` becomes a block with the disclaimer + summary."""
+        data = _read_fixture("sample-si-uksi-1996-690.xml")
+        blocks = UKTextParser().parse_text(data)
+        notes = next((b for b in blocks if b.block_type == "explanatory-notes"), None)
+        assert notes is not None
+        text = " ".join(p.text for v in notes.versions for p in v.paragraphs)
+        assert "(This note is not part of the Regulations)" in text
+        assert "These Regulations amend the fees" in text
+
+    def test_si_footnotes_emit_dedicated_block(self):
+        """Top-level `<Footnotes>` become a footnote-definition block."""
+        data = _read_fixture("sample-si-uksi-2012-1866.xml")
+        blocks = UKTextParser().parse_text(data)
+        footnotes = next((b for b in blocks if b.block_type == "footnotes"), None)
+        assert footnotes is not None
+        text = " ".join(p.text for v in footnotes.versions for p in v.paragraphs)
+        # GitHub-style footnote definitions, one per ukm:Footnote id.
+        assert "[^f00001]:" in text
+        assert "[^f00002]:" in text
+        assert "[^f00003]:" in text
+
+    def test_si_with_zero_p1_blocks_still_emits_content(self):
+        """Regression: SI with no `<P1>` and no schedules must still parse.
+
+        Both fixtures here have ``NumberOfProvisions="0"``, no schedules,
+        and no ``<P1>`` elements. Before PR #1 they returned 0 blocks
+        and crashed the bootstrap at ``bootstrap.py:225``.
+        """
+        for fixture in ("sample-si-uksi-1996-690.xml", "sample-si-uksi-2012-1866.xml"):
+            data = _read_fixture(fixture)
+            blocks = UKTextParser().parse_text(data)
+            assert blocks, f"{fixture}: 0 blocks would crash the bootstrap"

--- a/tests/test_parser_uk.py
+++ b/tests/test_parser_uk.py
@@ -475,7 +475,15 @@ class TestSITextParser:
         assert "Derek Conway" in text
 
     def test_si_explanatory_notes_emit_dedicated_block(self):
-        """`<ExplanatoryNotes>` becomes a block with the disclaimer + summary."""
+        """`<ExplanatoryNotes>` becomes a block with the disclaimer, summary,
+        and every nested sub-paragraph that explains the regulation changes.
+
+        Regression: previously the body-level ``<P>`` carrying a lead-in
+        ``<Text>`` followed by ``<P2>`` siblings only emitted the lead-in,
+        silently dropping every fee-change sub-paragraph. The structural
+        decision in ``_render_plain_paragraph`` must be local to each
+        ``<P>``, not based on the shared builder's accumulated state.
+        """
         data = _read_fixture("sample-si-uksi-1996-690.xml")
         blocks = UKTextParser().parse_text(data)
         notes = next((b for b in blocks if b.block_type == "explanatory-notes"), None)
@@ -483,6 +491,11 @@ class TestSITextParser:
         text = " ".join(p.text for v in notes.versions for p in v.paragraphs)
         assert "(This note is not part of the Regulations)" in text
         assert "These Regulations amend the fees" in text
+        # Sub-paragraphs nested under the lead-in `<P><Text>…</Text><P2>…</P2>` envelope.
+        assert "£58.00 per hour" in text
+        assert "£70.00 per hour" in text
+        assert "£11.50 per hour" in text
+        assert "for examination staff" in text
 
     def test_si_footnotes_emit_dedicated_block(self):
         """Top-level `<Footnotes>` become a footnote-definition block."""
@@ -495,6 +508,30 @@ class TestSITextParser:
         assert "[^f00001]:" in text
         assert "[^f00002]:" in text
         assert "[^f00003]:" in text
+
+    def test_si_footnote_refs_render_in_body(self):
+        """`<FootnoteRef Ref="…"/>` markers must survive inline in body text.
+
+        Without the inline marker the body silently drops the reference and
+        leaves the `[^id]: …` definitions in the Footnotes block dangling
+        with nothing tying them back. Lawyer-visible regression that
+        ``_render_footnotes`` alone (PR #61's original scope) cannot fix.
+        """
+        data = _read_fixture("sample-si-uksi-2012-1866.xml")
+        blocks = UKTextParser().parse_text(data)
+        # The body of this SI is a single `<Resolution>` carrying three
+        # FootnoteRefs against citations of the 1948 Act, the 1981 Act,
+        # and the 7 March 2005 Resolution.
+        body_text = " ".join(
+            p.text
+            for b in blocks
+            if b.block_type not in ("footnotes",)
+            for v in b.versions
+            for p in v.paragraphs
+        )
+        assert "[^f00001]" in body_text
+        assert "[^f00002]" in body_text
+        assert "[^f00003]" in body_text
 
     def test_si_with_zero_p1_blocks_still_emits_content(self):
         """Regression: SI with no `<P1>` and no schedules must still parse.


### PR DESCRIPTION
Lift content the SI bootstrap §7 reviewer flagged as silently dropped, plus the two SIs that crashed the bootstrap with `parse_suvestine returned 0 blocks`.

### Changes

- `<SecondaryPreamble>` (SI equivalent of `<Preamble>`) is now walked, so enacting text and resolutions land in the preamble block.
- SI prelim dates `<MadeDate>`, `<LaidDate>`, `<ComingIntoForce>` emit as preamble paragraphs.
- `<SignedSection>`, `<ExplanatoryNotes>`, `<Footnotes>` each become a dedicated block. They were dropped before – `_walk_recursive` doesn't know their shape, and the latter two sit outside `<Body>`.
- Body-level `<P>` with no own `<Text>` but `<P2>` / `<BlockAmendment>` children falls back to the inline renderer used inside `<P1para>`. SIs that omit the `<P1>` envelope – uksi-1996-690 (fee amender) and uksi-2012-1866 (House of Commons resolution) – now emit their regulations and quoted amendments instead of zero blocks.
- `<AppendText>` of pure punctuation (the trailing "." after a `<BlockAmendment>`) is suppressed so it stops surfacing as an orphan "." paragraph.

### Verification

Parsed all 82,628 enacted SIs in the bulk corpus through the patched parser: 0 zero-block failures (was 2), 0 exceptions. Full test suite: 1,689 pass, 27 skipped, 0 fail (+7 regression tests, +2 fixtures).

Primary legislation paths unchanged – new branches in `_gather_section_blocks` guard on element names ukpga / asp / asc / nia don't carry, and the `_render_plain_paragraph` fallback only fires when there's no direct `<Text>` content.

### Context

First of the three parser fix PRs needed before the SI bootstrap retry. Addresses §7.2 finding no. 1 (preamble / signatory / explanatory notes / footnotes silently dropped). Remaining two fixes cover bare `<Tabular>` / `<Form>` rendering in `<ScheduleBody>`, and metadata + heading polish.

Sibling PRs: https://github.com/legalize-dev/legalize-pipeline/pull/56 (FastImporter additive-seeding fix) and https://github.com/legalize-dev/legalize-pipeline/pull/60 (MAINTAINERS.md commit-type cleanup).
Follows: https://github.com/legalize-dev/legalize-pipeline/pull/55 (SI type registration).
