### PR TITLE
feat: generate a LICENSE file in every country repo

### DIFF
--- a/src/legalize/committer/license.py
+++ b/src/legalize/committer/license.py
@@ -1,0 +1,39 @@
+"""Render a country repo's ``LICENSE`` file from :mod:`legalize.country_meta`.
+
+Unlike the README (written in the country's native language), the LICENSE is
+written in English so it is universally readable, with the country's own
+data-license statement embedded verbatim. The pipeline code is MIT; the
+legislative content follows each official source's terms (``meta.data_license``).
+
+Like the README and funding config, this is a repo-level meta file, NOT a law
+file and NOT part of the legislative record.
+"""
+
+from __future__ import annotations
+
+from legalize.country_meta import CountryMeta
+
+PIPELINE_URL = "https://github.com/legalize-dev/legalize-pipeline"
+
+
+def render_license(meta: CountryMeta) -> str:
+    """Render the English ``LICENSE`` text for one country repo."""
+    return (
+        f"LEGALIZE — {meta.name}: legislation as open data\n"
+        "\n"
+        "SOFTWARE / PIPELINE\n"
+        "The software that generates and maintains this repository is open source\n"
+        f"under the MIT License:\n"
+        f"  {PIPELINE_URL}\n"
+        "\n"
+        "LEGISLATIVE CONTENT (DATA)\n"
+        f"{meta.data_license}\n"
+        "These are official public-sector texts reproduced from their official\n"
+        "source. The original source of each document is recorded in the `source`\n"
+        "field of that file's YAML front matter.\n"
+        "\n"
+        "DISCLAIMER\n"
+        "Automated reproduction of official sources. This is not an official or\n"
+        "verified legal text. Always consult the official source for authoritative\n"
+        "versions.\n"
+    )

--- a/src/legalize/committer/repo_meta.py
+++ b/src/legalize/committer/repo_meta.py
@@ -1,8 +1,8 @@
 """Repo-level meta files committed to each country repo.
 
 These are NOT law files and are NOT part of the legislative record. They are
-project metadata (funding config today; README / LICENSE could be added here
-later). They are committed as a standalone meta commit which the reform-history
+project metadata (funding config, README, and LICENSE). They are committed as a
+standalone meta commit which the reform-history
 sync ignores, because they carry no ``Source-Date`` trailer (see
 ``state/store.py``).
 """
@@ -26,6 +26,7 @@ def repo_meta_files(country: str) -> dict[str, str]:
     everywhere; the README is generated in the country's own language when
     presentation metadata exists for it (see :mod:`legalize.country_meta`).
     """
+    from legalize.committer.license import render_license
     from legalize.committer.readme import render_readme
     from legalize.country_meta import COUNTRY_META
 
@@ -34,5 +35,6 @@ def repo_meta_files(country: str) -> dict[str, str]:
     meta = COUNTRY_META.get(country)
     if meta is not None:
         files["README.md"] = render_readme(meta)
+        files["LICENSE"] = render_license(meta)
 
     return files

--- a/tests/test_repo_meta_license.py
+++ b/tests/test_repo_meta_license.py
@@ -1,0 +1,44 @@
+"""Tests for the per-country LICENSE file generated into each country repo."""
+
+from __future__ import annotations
+
+from legalize.committer.license import PIPELINE_URL, render_license
+from legalize.committer.repo_meta import repo_meta_files
+from legalize.country_meta import COUNTRY_META
+
+
+def test_repo_meta_includes_license_for_known_country():
+    files = repo_meta_files("es")
+    assert "LICENSE" in files
+    assert "README.md" in files
+    assert ".github/FUNDING.yml" in files
+
+
+def test_unknown_country_gets_funding_only_no_license():
+    files = repo_meta_files("zz")
+    assert ".github/FUNDING.yml" in files
+    assert "LICENSE" not in files
+    assert "README.md" not in files
+
+
+def test_license_embeds_mit_pipeline_disclaimer_and_country_data_license():
+    meta = COUNTRY_META["es"]
+    text = render_license(meta)
+    # MIT pipeline pointer
+    assert "MIT License" in text
+    assert PIPELINE_URL in text
+    # The country's own data-license statement, verbatim
+    assert meta.data_license in text
+    # Country name and the non-official-text disclaimer
+    assert meta.name in text
+    assert "not an official or" in text.lower()
+
+
+def test_license_renders_for_every_country_with_meta():
+    # Every country that gets a README must also get a valid, non-empty LICENSE
+    # carrying its specific data-license string (they are heterogeneous).
+    for code, meta in COUNTRY_META.items():
+        text = render_license(meta)
+        assert text.strip(), f"empty LICENSE for {code}"
+        assert meta.data_license in text, f"data_license missing for {code}"
+        assert PIPELINE_URL in text, f"pipeline URL missing for {code}"


### PR DESCRIPTION
## What
`committer/repo_meta.py` now writes a per-country **`LICENSE`** file into each country repo, alongside the existing `README.md` and `.github/FUNDING.yml`.

New `committer/license.py::render_license(meta)` renders an **English** LICENSE that embeds:
- **Software / pipeline:** MIT (link to legalize-pipeline).
- **Legislative content:** the country's own `data_license` statement (these are heterogeneous: BOE reuse w/ citation for ES, Etalab for FR, CC-BY for EU/IE/AR, public domain for US/DE, etc.).
- **Disclaimer:** automated reproduction, not an official/verified legal text.

## Why
Generated repos (e.g. `legalize-es`, ~1.8k stars) had **no LICENSE file**, so GitHub can't detect a license and the open-data offering is ambiguous. The **Digital Public Goods** application requires it (indicator 2, open licensing). A single blanket license would be wrong, so the LICENSE is per-country, reusing the already-curated `data_license` field.

## Tests
`tests/test_repo_meta_license.py`: LICENSE present for known countries, absent for unknown (FUNDING-only), and renders a non-empty LICENSE carrying the correct `data_license` + MIT pointer for every country in `COUNTRY_META`.

## Note
This handles all **future** repo writes. Existing repos are backfilled separately (same rendered content, committed as the Legalize bot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)