### PR TITLE
chore(ci): re-enable UK in daily cron matrix

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -30,10 +30,7 @@ jobs:
         #       fetcher, so the daily always clamps to the last 10 days and
         #       finds nothing. Re-enable once a modern reform source lands.
         #   ro: bootstrap only, not yet wired for daily updates.
-        #   uk: paused — UK maintainer (@florinungur) is running the SI bulk
-        #       bootstrap (~150K commits) locally onto legalize-uk. Re-enable
-        #       once he confirms the push has landed.
-        country: ${{ fromJson(inputs.country && format('["{0}"]', inputs.country) || '["es","fr","at","de","se","pt","lv","ad","lt","ee","pl","gr","nl","be","cz","fi","it","lu","eu"]') }}
+        country: ${{ fromJson(inputs.country && format('["{0}"]', inputs.country) || '["es","fr","at","de","se","pt","lv","ad","lt","ee","pl","gr","nl","be","cz","fi","it","lu","eu","uk"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
Add `uk` back to the daily-update matrix and drop the now-stale exclusion comment.

UK was paused while the statutory-instrument bulk bootstrap ran locally onto `legalize-uk`; that finished and the commits have landed, so the daily can resume. While paused, `legalize-uk` gets no daily updates — no new Acts/SIs, no new point-in-time versions, no ongoing amendment tracking.

The `workflow_dispatch` input description already lists `uk`, so this re-syncs the matrix with it.