### PR TITLE
fix(pipeline): skip norm on suvestine failure instead of committing consolidated text

### DIFF
--- a/src/legalize/pipeline.py
+++ b/src/legalize/pipeline.py
@@ -271,20 +271,29 @@ def generic_fetch_one(
             blocks = text_parser.parse_text(text_data)
             reforms = _extract_reforms_generic(text_parser, client, norm_id, blocks, text_data)
 
-            # Suvestine: replace blocks + reforms with versioned historical data
+            # Suvestine: replace blocks + reforms with versioned historical data.
+            # For a suvestine-capable country a fetch/parse failure is a hard
+            # skip: falling through to the consolidated text would commit it as
+            # a fabricated "original version" (wrong label + date), violating the
+            # commit-integrity rule. Skip the norm and log — the next run retries.
             if hasattr(text_parser, "parse_suvestine") and hasattr(client, "get_suvestine"):
                 try:
                     suvestine_data = client.get_suvestine(norm_id)
                     sv_blocks, sv_reforms = text_parser.parse_suvestine(suvestine_data, norm_id)
-                    if sv_reforms:
-                        blocks = sv_blocks
-                        reforms = sv_reforms
-                        console.print(f"    [dim]Suvestine: {len(sv_reforms)} versions[/dim]")
                 except Exception:
-                    logger.warning(
-                        "Suvestine unavailable for %s, using consolidated text",
+                    logger.error(
+                        "Suvestine fetch/parse failed for %s; skipping norm "
+                        "(will retry next run) rather than committing consolidated "
+                        "text as a fabricated version",
                         norm_id,
+                        exc_info=True,
                     )
+                    console.print(f"  [red]✗ Suvestine failed for {norm_id}, skipping[/red]")
+                    return None
+                if sv_reforms:
+                    blocks = sv_blocks
+                    reforms = sv_reforms
+                    console.print(f"    [dim]Suvestine: {len(sv_reforms)} versions[/dim]")
 
             norm = ParsedNorm(
                 metadata=metadata,

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -156,6 +156,58 @@ class TestGenericFetchErrorHandling:
         assert "NORM-003" in result
         assert "NORM-002" not in result
 
+    def test_fetch_one_skips_norm_on_suvestine_failure(self, test_config):
+        """A suvestine-capable country whose get_suvestine raises must skip the
+        norm (return None), never fall back to committing the consolidated text
+        as a fabricated 'original version' (commit-integrity rule).
+        """
+        d = date(2024, 1, 1)
+        meta = NormMetadata(
+            title="Test",
+            short_title="Test",
+            identifier="TEST-SV",
+            country="es",
+            rank=Rank.LEY,
+            publication_date=d,
+            status=NormStatus.IN_FORCE,
+            department="Test",
+            source="https://example.com/test",
+        )
+
+        # Client supports suvestine but the fetch fails (e.g. an upstream 504).
+        mock_client = MagicMock(
+            spec=["get_metadata", "get_text", "get_suvestine", "__enter__", "__exit__"]
+        )
+        mock_client.get_metadata.return_value = b"<metadata/>"
+        # get_text must be a real function: the pipeline inspects its
+        # __code__.co_varnames to decide whether to pass meta_data.
+        mock_client.get_text = lambda norm_id, **kwargs: b"<text/>"
+        mock_client.get_suvestine.side_effect = requests.RequestException("504")
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        mock_client_cls = MagicMock()
+        mock_client_cls.create.return_value = mock_client
+
+        # Parser is suvestine-capable and parses consolidated text fine.
+        mock_text_parser = MagicMock(spec=["parse_text", "parse_suvestine"])
+        mock_text_parser.parse_text.return_value = [
+            _make_block("a1", "Articulo 1", [_make_version("TEST-SV", d, "Texto.")]),
+        ]
+
+        mock_meta_parser = MagicMock(spec=["parse"])
+        mock_meta_parser.parse.return_value = meta
+
+        with (
+            patch("legalize.countries.get_client_class", return_value=mock_client_cls),
+            patch("legalize.countries.get_text_parser", return_value=mock_text_parser),
+            patch("legalize.countries.get_metadata_parser", return_value=mock_meta_parser),
+        ):
+            result = generic_fetch_one(test_config, "es", "TEST-SV", force=True)
+
+        assert result is None
+        mock_client.get_suvestine.assert_called_once()
+
     def test_fetch_one_returns_none_on_parse_error(self, test_config):
         """Mock client that returns data, but parser.parse raises ValueError.
         Verify returns None.


### PR DESCRIPTION
## What

When a **suvestine-capable** country's multi-version fetch (`get_suvestine` / `parse_suvestine`) raised, the shared caller in `generic_fetch_one` swallowed the exception and fell through to the **consolidated** text, committing it as a fabricated `— original version {year}` with the wrong label and date. This violates the commit-integrity rule (the git history must contain only real legislative versions).

Seen live on a 504 for `ukpga-2006-46` (dated `2026-04-06`, actually the current consolidated text). Reported by @florinungur — thanks.

## Fix

On a suvestine fetch/parse failure: log at **error** level (`exc_info`) and **skip the norm** (`return None`) so the daily cron retries it next run, rather than substituting consolidated text silently.

Scoped deliberately:
- The legitimate **empty-versions** path (`if sv_reforms:` → never-amended laws) is **unchanged**.
- Countries **without** suvestine support never enter this block, so they're unaffected.

## Test

`test_fetch_one_skips_norm_on_suvestine_failure` — a suvestine-capable client whose `get_suvestine` raises must return `None`, never commit consolidated text.

Full suite: 1700 passed, 27 skipped. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)