### PR TITLE
fix(nl): double daily request rate so the daily job fits the CI budget

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -308,10 +308,14 @@ countries:
     cache_dir: ".cache"
     # Bootstrap downloads every historical expression of every law (the BWB
     # preserves them all) and produces one git commit per real reform.
-    # Start at 4 workers × 2 req/s = 8 req/s effective — tuned for politeness
-    # against zoekservice.overheid.nl + repository.officiele-overheidspublicaties.nl.
+    # 2 workers × 4 req/s = 8 req/s effective — tuned for politeness against
+    # zoekservice.overheid.nl + repository.officiele-overheidspublicaties.nl.
+    # The daily flow is single-threaded, so 4 req/s is also its effective rate
+    # (was 2): heavily-amended laws refetch their full expression history each
+    # run, and at 2 req/s the daily job overran the CI time budget. 8 req/s
+    # effective for bootstrap is unchanged (workers halved, rate doubled).
     # Estimated 22K active laws × ~6 expressions avg → ~130K downloads → ~4-5 h.
-    max_workers: 4
+    max_workers: 2
     source:
       # Basis Wetten Bestand (BWB) — official Dutch consolidated legislation.
       # Two interfaces: SRU (discovery + metadata) and HTTPS repository (full XML).
@@ -321,7 +325,7 @@ countries:
       portal_url: "https://wetten.overheid.nl"
       request_timeout: 30
       max_retries: 5
-      requests_per_second: 2.0
+      requests_per_second: 4.0
       # Download every historical expression of every law so git history
       # reflects each real reform. Set to false for a lightweight bootstrap
       # that only commits the current state.


### PR DESCRIPTION
## Problem

The **nl** daily job has failed every scheduled run since ~25 June, leaving the whole *Daily update* workflow red. (`fail-fast: false` is already set, so the other 18 countries were unaffected — only the aggregate run status showed red.)

Root cause: the daily is **single-threaded** and refetches each modified law's **full expression history** via `get_text` (heavily-amended laws hit 100+ expression downloads — e.g. `BWBR0004939`: 132 expressions / 73s at 2 req/s). Over the 10-day lookback window the step ran ~3h and was killed. `latest-only` was rejected because it changes the rendered output (cross-reference `z=`/`g=` dates + a resolved reference differ), and output format is FINAL.

## Fix (nl-only, output byte-identical)

Halve `max_workers` (4→2) and double `requests_per_second` (2→4):

| flow | before | after |
|---|---|---|
| bootstrap (N workers × rps) | 4×2 = **8 req/s** | 2×4 = **8 req/s** (unchanged) |
| daily (single-threaded) | 1×2 = **2 req/s** | 1×4 = **4 req/s** (2×) |

Same expressions fetched in the same order → identical Markdown. Empirically 0×429 across 50 live requests at 4–10 req/s against overheid.nl (which already sustains 8 req/s during bootstrap; `at` runs at 25). The client also retries 429/5xx with backoff, so it degrades gracefully.

Brings the daily run from ~3h to ~1.5h, well under the CI budget. Will validate with a manual `workflow_dispatch` for nl after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)