### PR TITLE
fix(pipeline): checkpoint the daily by pushing after each completed day

### DIFF
--- a/src/legalize/pipeline.py
+++ b/src/legalize/pipeline.py
@@ -142,6 +142,7 @@ def generic_daily(
 
     repo = GitRepo(cc.repo_path, config.git.committer_name, config.git.committer_email)
     commits_created = 0
+    pushed = 0  # commits already pushed to the remote (checkpoint tracker)
     errors: list[str] = []
 
     text_parser = get_text_parser(country)
@@ -214,6 +215,22 @@ def generic_daily(
                     errors.append(msg)
 
             state.last_summary_date = current_date
+
+            # Checkpoint: push after each completed day so a mid-run failure
+            # keeps the days already finished. Only push at day boundaries —
+            # the next run resumes from the newest Source-Date, so pushing
+            # mid-day would make it skip that day's remaining norms.
+            if not dry_run and config.git.push and commits_created > pushed:
+                try:
+                    repo.push()
+                    pushed = commits_created
+                except Exception:
+                    logger.warning(
+                        "Checkpoint push failed after %s; commits stay local "
+                        "and retry at the next day boundary or finalize",
+                        current_date,
+                        exc_info=True,
+                    )
 
     return finalize_daily(
         repo,

--- a/tests/test_daily_at.py
+++ b/tests/test_daily_at.py
@@ -306,6 +306,69 @@ class TestDailyATOrchestration:
         state_path = Path(config.get_country("at").state_path)
         assert state_path.exists()
 
+    def test_checkpoint_pushes_after_each_day(self, tmp_path):
+        """A multi-day daily run pushes after each completed day (checkpoint),
+        not only once at the end — so a mid-run failure keeps finished days and
+        the next run resumes from the last completed day instead of restarting.
+        """
+        from legalize.models import Block, NormMetadata, NormStatus, Paragraph, Rank, Version
+
+        config = self._make_config(tmp_path)
+        config.git.push = True  # checkpoint only pushes when pushing is enabled
+        mock_client, mock_client_cls, mock_discovery, mock_disc_cls = self._mock_countries()
+        # Two days, one modified norm each.
+        mock_discovery.discover_daily.side_effect = [iter(["AT-1"]), iter(["AT-2"])]
+        mock_client.get_metadata.return_value = b"<m/>"
+        mock_client.get_text.return_value = b"<t/>"
+
+        def _meta(_data, nid):
+            return NormMetadata(
+                title=nid,
+                short_title=nid,
+                identifier=nid,
+                country="at",
+                rank=Rank.LEY,
+                publication_date=date(2026, 4, 1),
+                status=NormStatus.IN_FORCE,
+                department="T",
+                source="https://example.com/",
+            )
+
+        meta_parser = MagicMock(spec=["parse"])
+        meta_parser.parse.side_effect = _meta
+        block = Block(
+            id="a1",
+            block_type="precepto",
+            title="Art 1",
+            versions=(
+                Version(
+                    norm_id="x",
+                    publication_date=date(2026, 4, 1),
+                    effective_date=date(2026, 4, 1),
+                    paragraphs=(Paragraph(css_class="p", text="txt"),),
+                ),
+            ),
+        )
+        text_parser = MagicMock(spec=["parse_text"])
+        text_parser.parse_text.return_value = [block]
+
+        with (
+            patch("legalize.countries.get_client_class", return_value=mock_client_cls),
+            patch("legalize.countries.get_discovery_class", return_value=mock_disc_cls),
+            patch("legalize.countries.get_metadata_parser", return_value=meta_parser),
+            patch("legalize.countries.get_text_parser", return_value=text_parser),
+            patch(
+                "legalize.pipeline.resolve_dates_to_process",
+                return_value=[date(2026, 4, 1), date(2026, 4, 2)],
+            ),
+            patch("legalize.pipeline.GitRepo.push") as mock_push,
+        ):
+            generic_daily(config, "at", target_date=None)
+
+        # Each of the two days produced a commit → pushed per day (>= 2),
+        # not the single end-of-run push the old code did.
+        assert mock_push.call_count >= 2
+
     def test_state_saved_after_run(self, tmp_path):
         config = self._make_config(tmp_path)
         mock_client, mock_client_cls, mock_discovery, mock_disc_cls = self._mock_countries()


### PR DESCRIPTION
## Problem

The daily pushed **only once**, at the end of `finalize_daily`. On CI the country repo and state file are ephemeral, so a mid-run kill lost everything — the next run reprocessed the whole lookback window from scratch. That's the mechanism behind the nl spiral: a run that couldn't finish the window in one shot never advanced, so the backlog never shrank.

## Fix

Push after **each completed day** inside the loop. Progress is now monotonic — a mid-run failure keeps every finished day, and the next run resumes from the last one (inferred from the newest `Source-Date`).

**Day boundaries only, never mid-day.** Resume granularity is the day (`infer_last_date_from_git` reads the newest `Source-Date`), so a mid-day push would advance the inferred date and make the next run **skip that day's remaining norms** — a silent reform loss. A wall-clock timer would hit exactly that trap; per-day is the only safe checkpoint without per-norm resume state (which real volumes don't need).

Checkpoint pushes are best-effort (logged, not fatal); `finalize_daily` still does the final push as a safety net. Loss is now bounded to at most one in-progress day.

## Test

`test_checkpoint_pushes_after_each_day` — a two-day run pushes per day (≥2 pushes), where the old code pushed once. Full suite: 1701 passed, 27 skipped. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)