### PR TITLE
chore(ci): cap the daily job at 55 min (under the GitHub App token lifetime)

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -22,6 +22,14 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    # The GitHub App token minted at job start lives ~1h, and pushes are the
+    # only durable output — anything processed after it expires is wasted work
+    # that can never be pushed. Cap the job just under the token lifetime so a
+    # slow country (e.g. nl catching up a large backlog) stops instead of
+    # burning hours it can't commit. Per-day checkpoint pushes (see
+    # pipeline.generic_daily) persist whatever completed within the window, and
+    # the next run resumes from there. Fast countries finish in minutes.
+    timeout-minutes: 55
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Why

The GitHub App token minted at the start of each daily job lives **~1 hour**, and **pushing is the only durable output**. When nl catches up a large backlog the job runs ~2.5h, so the end-of-run push happens long after the token expired → 403 → nothing persists, and ~1.5h of compute is wasted producing commits that can never be pushed.

## Change

`timeout-minutes: 55` on the daily job — just under the token lifetime (token is minted ~1min in and lives ~61min, so 55 leaves margin for the final push to use a live token).

Combined with the per-day checkpoint push (#72), each run now:
- persists every day it completes **within** the token window (checkpoint pushes succeed while the token is alive),
- **stops at 55 min** instead of burning hours it can't commit,
- and the next run resumes from the last pushed day (`infer_last_date_from_git`).

Fast countries finish in minutes, so the cap only ever bites a genuine backlog. nl converges over a few runs, then runs green once its window fits inside the window.

No code change — CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)