### PR TITLE
perf(ci): blobless checkout of country repos in the daily job

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -55,7 +55,15 @@ jobs:
           repository: legalize-dev/legalize-${{ matrix.country }}
           path: repos/${{ matrix.country }}
           token: ${{ steps.app-token.outputs.token }}
+          # Blobless partial clone: full commit graph (needed by
+          # infer_last_date_from_git's `git log --grep=Source-Date`) but no
+          # historical blobs. On a large repo (nl ≈ 2 GB of per-reform history)
+          # a full fetch-depth:0 checkout downloaded every past version and ate
+          # most of the job's time budget; blobless fetches only the current
+          # tree's blobs (+ any it needs on demand) and cuts checkout to minutes,
+          # leaving the window for actual processing. Harmless for small repos.
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:


### PR DESCRIPTION
## Problem

The daily catch-up for **nl** made **zero progress** across three 55-min runs: `legalize-nl` HEAD never moved off 23 Jun, even for a single-day dispatch. Root cause: `legalize-nl` is ~2 GB of per-reform history, and the `fetch-depth: 0` checkout downloads **every historical blob** (every past version of every file across ~150K commits), eating ~45 min of the 55-min job budget (#73) — so the daily step never finished processing + pushing even one day.

## Fix

`filter: blob:none` on the country-repo checkout — a **blobless partial clone**:
- keeps the **full commit graph** (needed by `infer_last_date_from_git`'s `git log --grep=Source-Date`),
- skips **historical blobs**, fetching only the current tree's blobs (+ any needed on demand),
- cuts checkout from tens of minutes to minutes → the job's window goes to actual processing.

The daily only appends commits and reads current files, so it never needs historical blobs. Harmless (a small speedup) for the smaller repos too.

CI config only. After merge I'll re-dispatch nl and confirm HEAD advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)