### PR TITLE
fix: skip future-dated Source-Date trailers when inferring the daily start

### DIFF
--- a/src/legalize/state/store.py
+++ b/src/legalize/state/store.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 # Default safety cap for automatic lookback (no explicit --date)
 MAX_LOOKBACK_DAYS = 10
 
+# How far back to walk pipeline commits looking for a usable Source-Date.
+# Bootstrap writes one commit per norm in the norms' own chronological
+# order, so a repo can open with a long run of future-dated commits at the
+# tip: the worst observed is legalize-it with 72 in a row. 500 leaves ample
+# headroom without walking 86k commits on every daily run.
+MAX_COMMITS_SCANNED = 500
+
 
 def resolve_dates_to_process(
     state: "StateStore",
@@ -82,29 +89,118 @@ def resolve_dates_to_process(
     return dates
 
 
-def infer_last_date_from_git(repo_path: str) -> date | None:
-    """Infer the last processed date from the most recent Source-Date trailer.
+def _parse_iso_date(value: str) -> date | None:
+    """Parse an ISO date, returning None instead of raising on garbage."""
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
 
-    Uses ``git log --grep`` to find only pipeline commits (which carry a
-    Source-Date trailer), ignoring manual commits like README updates.
-    Works for any country — all pipeline commits use the same trailer.
+
+def latest_source_date(repo_path: str) -> date | None:
+    """Most recent ``Source-Date`` trailer that is not in the future.
+
+    Walks pipeline commits (the ones carrying the trailer) newest first;
+    manual commits such as the README/LICENSE sweeps carry no trailer and
+    are filtered out by ``--grep``. Returns None when no such commit is
+    found within ``MAX_COMMITS_SCANNED``.
+
+    Future-dated trailers have to be skipped rather than trusted: bootstrap
+    writes one commit per norm in the norms' own chronological order, and a
+    norm whose entry into force is years away carries that future date, so
+    a freshly bootstrapped repo opens with a run of them at the tip (72 in
+    a row in legalize-it; up to 2034-01-01 in legalize-lt).
+
+    This is also the corpus freshness signal: git commit dates are useless
+    for it, since the committer sets GIT_COMMITTER_DATE to the norm's own
+    date (see committer.git_ops.GitRepo.commit).
     """
+    today = date.today()
     try:
         result = subprocess.run(
-            ["git", "log", "-1", "--grep=Source-Date:", "--format=%B"],
+            [
+                "git",
+                "log",
+                f"-{MAX_COMMITS_SCANNED}",
+                "--grep=Source-Date:",
+                "--format=%B%x1e",
+            ],
             cwd=repo_path,
             capture_output=True,
             text=True,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            for line in result.stdout.splitlines():
-                if line.startswith("Source-Date: "):
-                    inferred = date.fromisoformat(line[len("Source-Date: ") :].strip())
-                    logger.info("Inferred last date from git: %s", inferred)
-                    return inferred
-    except (OSError, ValueError):
-        pass
+    except OSError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    for body in result.stdout.split("\x1e"):
+        for line in body.splitlines():
+            if not line.startswith("Source-Date: "):
+                continue
+            found = _parse_iso_date(line[len("Source-Date: ") :].strip())
+            if found is not None and found <= today:
+                return found
+            # Future-dated (or malformed) trailer: keep walking back.
+            break
+
     return None
+
+
+def has_pipeline_commits(repo_path: str) -> bool:
+    """Whether the repo contains any commit the pipeline produced."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--grep=Source-Date:", "--format=%H"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def infer_last_date_from_git(repo_path: str) -> date | None:
+    """Infer the date the daily should resume from.
+
+    Normally the most recent non-future ``Source-Date`` in the repo.
+
+    Reading the tip commit's trailer as-is is what broke: it left ``start``
+    beyond today, the date loop produced an empty range, and the daily
+    exited 0 having done nothing. Green CI, no output, and self-locking —
+    with no commit the trailer never moves. Seven countries sat frozen like
+    that for months before anyone noticed.
+
+    Fallback when the repo has pipeline commits but no usable trailer among
+    the scanned ones: the lookback horizon, so the daily re-checks the full
+    window it is allowed to process automatically. Re-processing that
+    window is safe (the committer dedupes by Source-Id + Norm-Id) and it is
+    already what the clamp in :func:`resolve_dates_to_process` does for any
+    repo further behind. Returning None here instead would reproduce the
+    exact silent no-op this guard exists to prevent — and the commit date
+    is no help, since the committer sets it to the norm's own date, which
+    in this scenario is precisely the future date we just rejected.
+    """
+    found = latest_source_date(repo_path)
+    if found is not None:
+        logger.info("Inferred last date from git: %s", found)
+        return found
+
+    if not has_pipeline_commits(repo_path):
+        return None
+
+    fallback = date.today() - timedelta(days=MAX_LOOKBACK_DAYS)
+    logger.warning(
+        "No Source-Date <= today in the last %d pipeline commits; resuming "
+        "from the %d-day lookback horizon (%s). This repo was most likely "
+        "bootstrapped and never updated since.",
+        MAX_COMMITS_SCANNED,
+        MAX_LOOKBACK_DAYS,
+        fallback,
+    )
+    return fallback
 
 
 @dataclass

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,157 @@
+"""Tests for the generic date-inference logic in ``legalize.state.store``.
+
+These cover the guard against future-dated ``Source-Date`` trailers, which
+silently froze seven country dailies (pl, lt, be, ee, fi, gr, it) for
+months: the trailer at the tip of a freshly bootstrapped repo is the norm's
+entry-into-force date, which can be years away.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import date, timedelta
+
+from legalize.state.store import (
+    MAX_LOOKBACK_DAYS,
+    StateStore,
+    infer_last_date_from_git,
+    latest_source_date,
+    resolve_dates_to_process,
+)
+
+TODAY = date.today()
+
+
+def _init_repo(path):
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=path, capture_output=True)
+    return path
+
+
+def _commit(repo, subject, source_date=None, commit_date=None):
+    """Add one commit, optionally with a Source-Date trailer and a fixed date."""
+    (repo / "law.md").write_text(subject)
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+    message = subject if source_date is None else f"{subject}\n\nSource-Date: {source_date}"
+    env = dict(os.environ)
+    if commit_date is not None:
+        stamp = f"{commit_date} 12:00:00 +0000"
+        env |= {"GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp}
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        env=env,
+    )
+
+
+class TestInferLastDateFromGit:
+    def test_uses_tip_trailer_when_not_in_the_future(self, tmp_path):
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "older", source_date="2026-03-01")
+        _commit(repo, "newest", source_date="2026-03-28")
+
+        assert infer_last_date_from_git(str(repo)) == date(2026, 3, 28)
+
+    def test_walks_past_future_dated_tip_commits(self, tmp_path):
+        """The legalize-lt shape: real data, then future entry-into-force norms."""
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "real data", source_date="2026-04-02")
+        _commit(repo, "enters into force in 2030", source_date="2030-01-01")
+        _commit(repo, "enters into force in 2034", source_date="2034-01-01")
+
+        assert infer_last_date_from_git(str(repo)) == date(2026, 4, 2)
+
+    def test_ignores_commits_without_a_trailer_while_walking(self, tmp_path):
+        """The 2026-06-23 README/LICENSE sweep sits on top of every country repo."""
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "real data", source_date="2026-04-02")
+        _commit(repo, "future norm", source_date="2034-01-01")
+        _commit(repo, "Add LICENSE: MIT pipeline code")
+
+        assert infer_last_date_from_git(str(repo)) == date(2026, 4, 2)
+
+    def test_falls_back_to_the_lookback_horizon_when_every_trailer_is_future(self, tmp_path):
+        """Never return None here: that is the silent no-op the guard prevents."""
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "future a", source_date="2029-01-01")
+        _commit(repo, "future b", source_date="2034-01-01")
+
+        assert latest_source_date(str(repo)) is None
+        assert infer_last_date_from_git(str(repo)) == TODAY - timedelta(days=MAX_LOOKBACK_DAYS)
+
+    def test_fallback_ignores_commit_dates(self, tmp_path):
+        """Commit dates carry the norm's own date, so they cannot be trusted.
+
+        committer.git_ops.GitRepo.commit sets GIT_COMMITTER_DATE to the
+        norm date, which for these repos is the same future date the
+        trailer was just rejected for. Using it would put start beyond
+        today and reproduce the empty range.
+        """
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "future norm", source_date="2034-01-01", commit_date=TODAY + timedelta(365))
+
+        assert infer_last_date_from_git(str(repo)) == TODAY - timedelta(days=MAX_LOOKBACK_DAYS)
+
+    def test_malformed_trailer_does_not_abort_the_walk(self, tmp_path):
+        """Old code let ValueError escape the loop and returned None for the repo."""
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "real data", source_date="2026-04-02")
+        _commit(repo, "broken", source_date="not-a-date")
+
+        assert infer_last_date_from_git(str(repo)) == date(2026, 4, 2)
+
+    def test_returns_none_without_any_pipeline_commit(self, tmp_path):
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "docs: add README")
+
+        assert infer_last_date_from_git(str(repo)) is None
+
+    def test_returns_none_for_empty_repo(self, tmp_path):
+        repo = _init_repo(tmp_path / "repo")
+
+        assert infer_last_date_from_git(str(repo)) is None
+
+    def test_returns_none_for_nonexistent_dir(self, tmp_path):
+        assert infer_last_date_from_git(str(tmp_path / "nope")) is None
+
+
+class TestResolveDatesUnblocksFrozenCountries:
+    """End-to-end: the user-visible symptom was an empty date range."""
+
+    def _frozen_repo(self, tmp_path):
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "real data", source_date=(TODAY - timedelta(days=60)).isoformat())
+        _commit(repo, "future norm", source_date="2034-01-01")
+        return repo
+
+    def test_produces_a_non_empty_date_range(self, tmp_path):
+        state = StateStore(str(tmp_path / "state.json"))
+        state.load()
+
+        dates = resolve_dates_to_process(state, str(self._frozen_repo(tmp_path)), target_date=None)
+
+        assert dates, "a future-dated tip must not silence the daily"
+        assert dates[-1] == TODAY
+        # The 60-day gap is still capped: the guard unblocks the daily going
+        # forward, it does not backfill. See MAX_LOOKBACK_DAYS.
+        assert dates[0] == TODAY - timedelta(days=MAX_LOOKBACK_DAYS)
+
+    def test_all_future_repo_also_gets_a_date_range(self, tmp_path):
+        """The bootstrap-only shape, where the fallback is the only path."""
+        repo = _init_repo(tmp_path / "repo")
+        _commit(repo, "future a", source_date="2029-01-01")
+        _commit(repo, "future b", source_date="2034-01-01")
+
+        state = StateStore(str(tmp_path / "state.json"))
+        state.load()
+
+        dates = resolve_dates_to_process(state, str(repo), target_date=None)
+
+        assert dates, "the fallback must produce work, not an empty range"
+        assert dates[0] == TODAY - timedelta(days=MAX_LOOKBACK_DAYS) + timedelta(days=1)
+        assert dates[-1] == TODAY


### PR DESCRIPTION
## The bug

`infer_last_date_from_git()` read the `Source-Date` trailer of the tip pipeline commit and used it as-is.

Bootstrap writes one commit per norm **in the norms' own chronological order**, so a norm whose entry into force is years away leaves a future date sitting at the tip of a freshly bootstrapped repo. `start = inferred + 1 day` then landed beyond today, `resolve_dates_to_process` generated an **empty date range**, and the daily exited 0 having done nothing.

Green CI, no output, and self-locking: with no commit produced, the trailer never moves.

Seven countries have been frozen this way since their April bootstrap:

| País | Source-Date en el tip | Futuros seguidos en el tip |
|---|---|---|
| lt | 2034-01-01 | 15 |
| pl | 2028-07-28 | 1 |
| be | 2029-01-01 | 7 |
| gr | 2027-07-12 | 2 |
| it | 2027-01-11 | 72 |
| fi | 2027-01-04 | 7 |
| ee | 2027-01-01 | 1 |

In the logs it looks like this — the `processing N day(s)` line never appears:

```
INFO  Inferred last date from git: 2034-01-01
```

The 2026-06-23 README/LICENSE sweep sitting on top of every country repo made this harder to spot: it equalised the "last commit" timestamp of 23 repos and hid how old the last *content* commit really was.

## The fix

Split into two functions:

**`latest_source_date()`** — walks pipeline commits newest first and returns the first `Source-Date` that is **not in the future**, capped at `MAX_COMMITS_SCANNED = 500`. The worst real run of consecutive future-dated commits is 72 (`legalize-it`), so 500 leaves headroom without walking 86k commits every run. A **malformed trailer no longer aborts the walk** — it used to let `ValueError` escape the loop and return `None` for the whole repo. This function is also the corpus freshness signal, which the stall alert builds on.

**`infer_last_date_from_git()`** — applies it, and when the repo has pipeline commits but no usable trailer among the scanned ones, falls back to the `MAX_LOOKBACK_DAYS` horizon so the daily re-checks the full window it may process automatically. Re-processing that window is safe (the committer dedupes by `Source-Id` + `Norm-Id`) and is already what `resolve_dates_to_process` does for any repo further behind. Returning `None` there would reproduce the same silent no-op this guard exists to prevent.

> The fallback deliberately **does not read the commit date**. `GitRepo.commit` sets `GIT_COMMITTER_DATE` to the norm's own date, so in the exact scenario the fallback exists for, the commit date *is* the same future date the trailer was just rejected for — using it produces `start = tomorrow` and the empty range comes straight back. An earlier revision of this branch had that bug; `test_fallback_ignores_commit_dates` and `test_all_future_repo_also_gets_a_date_range` now lock it out.

## Scope — read this before merging

**This unblocks the daily going FORWARD only. It does not close the accumulated gap.**

`resolve_dates_to_process` still clamps the automatic lookback to `MAX_LOOKBACK_DAYS = 10` (`store.py:19`), so a repo months behind resumes from 10 days ago and the months in between stay missing. Backfilling those needs an explicit `--date` run per country and is a separate decision — deliberately not done here.

It also does **not** fix the two countries whose dailies fail for unrelated reasons:

- **fr** — `fetcher/fr/daily.py:191` filters modified LEGITEXTs against an index built from the full LEGI dump on disk, which does not exist on an ephemeral CI runner (`Built text directory index: 0 entries`), so 100% of every increment is discarded. Last real content: 2026-04-03.
- **pt** — the OutSystems `apiVersion` hashes of diariodarepublica.pt changed; discovery gets HTML instead of JSON and raises `JSONDecodeError` daily. Last real content: 2026-05-14.

## Tests

New `tests/test_state_store.py` — 11 tests, **6 of which fail against the previous implementation**, including the end-to-end one that reproduces the exact symptom (`assert []`, an empty date range).

Covers: future-dated tip commits, an all-future repo (fallback path, end to end), the commit-date trap, a malformed trailer mid-walk, trailer-less commits (the LICENSE sweep) encountered while walking, plus the pre-existing behaviours kept as regression guards.

Full suite: 1712 passed, 27 skipped. `ruff check` + `ruff format --check` clean.

Co-Authored-By: Claude <noreply@anthropic.com>