### PR TITLE
fix(pt): restore the DRE daily — runtime endpoint discovery, URL-driven detail, loud failure

### DIFF
--- a/docs/pt-dre-api.md
+++ b/docs/pt-dre-api.md
@@ -1,0 +1,87 @@
+# Portugal — the DRE OutSystems API
+
+`diariodarepublica.pt` has no public API. The fetcher drives the same internal
+OutSystems endpoints the website's own JavaScript calls, so every DRE redeploy
+can move the ground under it. This file records what the contract looks like
+and how it broke, so the next break is a five-minute diagnosis.
+
+## The handshake
+
+Three things are needed before any endpoint answers with JSON:
+
+| What | Where it comes from |
+|---|---|
+| `X-CSRFToken` header | `AnonymousCSRFToken = "…"` in `/dr/scripts/OutSystems.js` |
+| `versionInfo.moduleVersion` | `versionToken` from `/dr/moduleservices/moduleversioninfo` |
+| `versionInfo.apiVersion` | per-action hash, from the screen's MVC JavaScript |
+
+Get any of them wrong and OutSystems replies with an **HTML error page**, not a
+JSON error. That is why `_post()` raises `DREApiError` on a non-JSON body
+instead of letting `resp.json()` throw somewhere further down.
+
+Session cookies matter too: the `requests.Session` picks them up during the
+handshake GETs. The same POST issued with plain `curl` and no cookie jar comes
+back `{"exception": {"message": "No role validation found"}}`.
+
+## Endpoints are discovered, not hardcoded
+
+Each screen's JS declares its data actions as:
+
+```js
+controller.callDataAction("DataActionGetDRByDataCalendarioAndCheckUserLog",
+                          "screenservices/dr/Home/home/DataActionGetDRByDataCalendarioAndCheckUserLog",
+                          "k+86ytikYIT6brie_oLQTQ", …)
+```
+
+`_SCREEN_ENDPOINTS` maps a logical endpoint to its JS file plus a list of known
+action-name **prefixes**, and `_resolve_endpoint()` reads both the URL and the
+hash out of that JS at session start. A hash rotation or a suffix added to an
+action name is absorbed automatically. A wholesale rename raises `DREApiError`
+listing every action the JS *does* contain, so adding the new prefix is a
+one-line change.
+
+## The May 2026 redeploy
+
+DRE renamed two of the three actions the fetcher uses:
+
+| Endpoint | Before | After |
+|---|---|---|
+| journals by date | `DataActionGetDRByDataCalendario` | `DataActionGetDRByDataCalendarioAndCheckUserLog` |
+| documents by journal | `DataActionGetDadosAndApplicationSettings` | unchanged |
+| document detail | `DataActionGetConteudoDataAndApplicationSettings` | `DataActionGetAllConteudoDetalheData` |
+
+The client logged `Could not extract apiVersion`, kept POSTing to the old URLs,
+got HTML back, and the daily still exited 0. Verified live 2026-08-20: the
+first two endpoints work again with the renamed actions.
+
+## Known open break: document detail input
+
+`DataActionGetAllConteudoDetalheData` resolves and answers 200, but the screen
+no longer accepts `DipLegisId` as its input variable — the string does not
+appear anywhere in `dr.Legislacao_Conteudos.Conteudo_Detalhe.mvc.js`. Probed
+without success: `ConteudoId`, `KeyConteudoId`, and both combined with
+`ParteId`/`FragmentoVersaoId`.
+
+An unrecognised input does **not** produce an error. DRE returns a default
+record — `Id: 0`, `Numero: ""`, `DataPublicacao: "1900-01-01"` — which would be
+committed as a law with no title, no date and no text. `get_document_detail()`
+therefore raises `DREApiError` on a record with neither `Numero` nor `ELI`.
+
+Until this is solved the daily discovers the right documents and then fails
+red on the first text fetch. Leads for whoever picks it up:
+
+- the document list gives `LinkSitemap`, e.g.
+  `/dr/detalhe/decreto-lei/169-2026-1159106557` — the screen is URL-driven, so
+  its input is probably derived from those segments rather than a raw id;
+- the response carries `KeyConteudoId`, `NewKey`, `PageName`, `ElementType`,
+  which smell like the resolved route parameters;
+- the surest route is capturing the real request in a browser devtools session
+  on a detail page and copying the `screenData.variables` block verbatim.
+
+## Re-checking the contract by hand
+
+```bash
+curl -s https://diariodarepublica.pt/dr/moduleservices/moduleversioninfo
+curl -s https://diariodarepublica.pt/dr/scripts/dr.Home.home.mvc.js \
+  | grep -o 'callDataAction("[^"]*"' | sort -u
+```

--- a/docs/pt-dre-api.md
+++ b/docs/pt-dre-api.md
@@ -54,29 +54,61 @@ The client logged `Could not extract apiVersion`, kept POSTing to the old URLs,
 got HTML back, and the daily still exited 0. Verified live 2026-08-20: the
 first two endpoints work again with the renamed actions.
 
-## Known open break: document detail input
+## The detail screen is URL-driven
 
-`DataActionGetAllConteudoDetalheData` resolves and answers 200, but the screen
-no longer accepts `DipLegisId` as its input variable — the string does not
-appear anywhere in `dr.Legislacao_Conteudos.Conteudo_Detalhe.mvc.js`. Probed
-without success: `ConteudoId`, `KeyConteudoId`, and both combined with
-`ParteId`/`FragmentoVersaoId`.
+`DataActionGetAllConteudoDetalheData` does **not** take a document id. The old
+`DipLegisId` input is gone — the string does not appear anywhere in
+`dr.Legislacao_Conteudos.Conteudo_Detalhe.mvc.js`. The screen's input
+parameters are the segments of its own URL:
+
+```js
+// screen model variables, read out of the live page
+"tipoIn", "_tipoInDataFetchStatus",
+"keyIn",  "_keyInDataFetchStatus",
+"parteIdIn", "_parteIdInDataFetchStatus"
+```
+
+which post as `Tipo`, `Key` and `ParteId`:
+
+```json
+{"screenData": {"variables": {
+  "Tipo": "decreto-lei",        "_tipoInDataFetchStatus": 1,
+  "Key":  "169-2026-1159106557", "_keyInDataFetchStatus": 1,
+  "ParteId": "0",                "_parteIdInDataFetchStatus": 1
+}}}
+```
+
+Both segments come straight from the `LinkSitemap` the document list already
+returns for every document — `/dr/detalhe/decreto-lei/169-2026-1159106557` —
+so nothing has to be reconstructed. `_split_sitemap_ref()` splits it, and
+`get_text()`/`get_metadata()` take that path as their reference instead of an
+id. The daily carries it through `doc_info["ref"]`.
+
+Do not try to rebuild the key from `TipoDiploma` + `Numero` + id: a Portaria
+numbered `349/2026/1` does not map to its slug the way you would guess. Use
+`LinkSitemap`.
 
 An unrecognised input does **not** produce an error. DRE returns a default
 record — `Id: 0`, `Numero: ""`, `DataPublicacao: "1900-01-01"` — which would be
-committed as a law with no title, no date and no text. `get_document_detail()`
-therefore raises `DREApiError` on a record with neither `Numero` nor `ELI`.
+committed as a law with no title, no date and no text.
+`get_document_detail()` therefore raises `DREApiError` on a record with
+neither `Numero` nor `ELI`.
 
-Until this is solved the daily discovers the right documents and then fails
-red on the first text fetch. Leads for whoever picks it up:
+### How the input names were found
 
-- the document list gives `LinkSitemap`, e.g.
-  `/dr/detalhe/decreto-lei/169-2026-1159106557` — the screen is URL-driven, so
-  its input is probably derived from those segments rather than a raw id;
-- the response carries `KeyConteudoId`, `NewKey`, `PageName`, `ElementType`,
-  which smell like the resolved route parameters;
-- the surest route is capturing the real request in a browser devtools session
-  on a detail page and copying the `screenData.variables` block verbatim.
+The routes are not in `dr.appDefinition.js`, and the screen's data action takes
+its inputs from the screen model rather than from explicit call arguments, so
+the MVC JS alone does not name them. They came out of the live page:
+
+```js
+const M = requirejs.s.contexts._.defined[
+  'dr.Legislacao_Conteudos.Conteudo_Detalhe.mvc$model'];
+Object.getOwnPropertyNames(Object.getPrototypeOf(new M.modelClass().variables));
+// → …, "tipoIn", "_tipoInDataFetchStatus", "keyIn", "_keyInDataFetchStatus", …
+```
+
+The `…In` suffix marks a screen input parameter; drop it and capitalise to get
+the name to post. Same trick works for any other DRE screen.
 
 ## Re-checking the contract by hand
 

--- a/src/legalize/fetcher/pt/client.py
+++ b/src/legalize/fetcher/pt/client.py
@@ -26,27 +26,54 @@ logger = logging.getLogger(__name__)
 _BASE = "https://diariodarepublica.pt/dr"
 _MODULE_VERSION_URL = f"{_BASE}/moduleservices/moduleversioninfo"
 _OUTSYSTEMS_JS_URL = f"{_BASE}/scripts/OutSystems.js"
-_DRS_BY_DATE_URL = f"{_BASE}/screenservices/dr/Home/home/DataActionGetDRByDataCalendario"
-_DOC_LIST_URL = (
-    f"{_BASE}/screenservices/dr/Legislacao_Conteudos"
-    "/Conteudo_Det_Diario/DataActionGetDadosAndApplicationSettings"
-)
-_DOC_DETAIL_URL = (
-    f"{_BASE}/screenservices/dr/Legislacao_Conteudos"
-    "/Conteudo_Detalhe/DataActionGetConteudoDataAndApplicationSettings"
-)
+# ─── Screen actions (discovered at runtime) ───
+#
+# The OutSystems endpoints live under screenservices/ and each one needs a
+# per-action ``apiVersion`` hash that changes on every DRE deploy.  Both the
+# URL path and the hash are published in the screen's MVC JavaScript as
+# ``callDataAction("ActionName", "screenservices/...", "apiVersionHash", ...)``
+# so we read them from there instead of hardcoding them.
+#
+# DRE also *renames* actions across deploys — the May 2026 redeploy turned
+# ``DataActionGetDRByDataCalendario`` into
+# ``DataActionGetDRByDataCalendarioAndCheckUserLog`` and replaced
+# ``DataActionGetConteudoDataAndApplicationSettings`` with
+# ``DataActionGetAllConteudoDetalheData`` — so each endpoint matches a list of
+# known action-name prefixes rather than one exact name.  A suffix added to an
+# existing name keeps working; a wholesale rename needs a new prefix here and
+# raises DREApiError until it gets one, instead of silently finding nothing.
+JOURNALS_BY_DATE = "journals_by_date"
+DOCUMENTS_BY_JOURNAL = "documents_by_journal"
+DOCUMENT_DETAIL = "document_detail"
 
-# Screen MVC JS files containing per-endpoint apiVersion hashes.
-# OutSystems requires a per-action apiVersion that changes on each deploy.
-_SCREEN_JS_MAP: dict[str, str] = {
-    "DataActionGetDRByDataCalendario": f"{_BASE}/scripts/dr.Home.home.mvc.js",
-    "DataActionGetDadosAndApplicationSettings": (
-        f"{_BASE}/scripts/dr.Legislacao_Conteudos.Conteudo_Det_Diario.mvc.js"
+_SCREEN_ENDPOINTS: dict[str, tuple[str, tuple[str, ...]]] = {
+    JOURNALS_BY_DATE: (
+        f"{_BASE}/scripts/dr.Home.home.mvc.js",
+        ("DataActionGetDRByDataCalendario",),
     ),
-    "DataActionGetConteudoDataAndApplicationSettings": (
-        f"{_BASE}/scripts/dr.Legislacao_Conteudos.Conteudo_Detalhe.mvc.js"
+    DOCUMENTS_BY_JOURNAL: (
+        f"{_BASE}/scripts/dr.Legislacao_Conteudos.Conteudo_Det_Diario.mvc.js",
+        ("DataActionGetDadosAndApplicationSettings",),
+    ),
+    DOCUMENT_DETAIL: (
+        f"{_BASE}/scripts/dr.Legislacao_Conteudos.Conteudo_Detalhe.mvc.js",
+        ("DataActionGetConteudoData", "DataActionGetAllConteudoDetalhe"),
     ),
 }
+
+# callDataAction("ActionName", "screenservices/...", "apiVersionHash", ...)
+_CALL_DATA_ACTION_RE = re.compile(
+    r'callDataAction\s*\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"'
+)
+
+
+class DREApiError(RuntimeError):
+    """The DRE OutSystems API broke its contract.
+
+    Raised instead of degrading to an empty result, so a DRE redeploy fails
+    the daily run in red rather than recording a silent "no new norms" day
+    and advancing the state past legislation we never saw.
+    """
 
 
 def _nested_get(d: dict, *keys: str, default: str = "") -> str:
@@ -82,15 +109,18 @@ class DREHttpClient(HttpClient):
         )
         self._csrf_token: str = ""
         self._module_version: str = ""
-        self._api_versions: dict[str, str] = {}  # action_name → apiVersion hash
+        # logical endpoint name → (absolute URL, apiVersion hash)
+        self._endpoints: dict[str, tuple[str, str]] = {}
         self._request_count = 0
         self._init_session()
 
     def _init_session(self) -> None:
-        """Initialize session: fetch CSRF token, module version, and API versions.
+        """Initialize session: CSRF token, module version, and screen endpoints.
 
-        OutSystems requires a per-action apiVersion hash that changes on each
-        platform deploy. We extract these from the screen MVC JavaScript files.
+        Every piece here is a hard requirement: without a CSRF token or an
+        apiVersion hash the OutSystems endpoints answer with an HTML error page
+        instead of JSON.  Anything missing raises DREApiError rather than
+        leaving the client half-configured to fail later as "no results".
         """
         # 1. Get CSRF token from OutSystems.js
         resp = self._request("GET", _OUTSYSTEMS_JS_URL)
@@ -103,9 +133,12 @@ class DREHttpClient(HttpClient):
             if match:
                 self._csrf_token = match.group(1)
                 break
-        logger.info(
-            "CSRF token obtained: %s...", self._csrf_token[:8] if self._csrf_token else "NONE"
-        )
+        if not self._csrf_token:
+            raise DREApiError(
+                f"No CSRF token found in {_OUTSYSTEMS_JS_URL} "
+                f"({len(resp.text)} bytes) — DRE changed the token format."
+            )
+        logger.info("CSRF token obtained: %s...", self._csrf_token[:8])
 
         # 2. Get module version
         resp = self._request("GET", _MODULE_VERSION_URL)
@@ -114,41 +147,41 @@ class DREHttpClient(HttpClient):
             self._module_version = version_data.get("versionToken", "")
         elif isinstance(version_data, list) and version_data:
             self._module_version = version_data[0].get("versionToken", "")
-        logger.info(
-            "Module version: %s", self._module_version[:20] if self._module_version else "NONE"
+        if not self._module_version:
+            raise DREApiError(
+                f"No versionToken in {_MODULE_VERSION_URL} response: {version_data!r:.200}"
+            )
+        logger.info("Module version: %s", self._module_version)
+
+        # 3. Resolve each screen endpoint (URL + apiVersion) from its MVC JS.
+        self._endpoints = {}
+        js_cache: dict[str, str] = {}
+        for name, (js_url, prefixes) in _SCREEN_ENDPOINTS.items():
+            if js_url not in js_cache:
+                js_cache[js_url] = self._request("GET", js_url).text
+            self._endpoints[name] = self._resolve_endpoint(name, js_cache[js_url], js_url, prefixes)
+
+    def _resolve_endpoint(
+        self, name: str, js_text: str, js_url: str, prefixes: tuple[str, ...]
+    ) -> tuple[str, str]:
+        """Find the URL and apiVersion of one screen action inside its MVC JS."""
+        actions = {
+            m.group(1): (m.group(2), m.group(3)) for m in _CALL_DATA_ACTION_RE.finditer(js_text)
+        }
+        for prefix in prefixes:
+            for action_name, (path, api_version) in actions.items():
+                if action_name.startswith(prefix):
+                    logger.info("Resolved %s → %s (apiVersion %s)", name, action_name, api_version)
+                    return f"{_BASE}/{path.lstrip('/')}", api_version
+        raise DREApiError(
+            f"No action matching {prefixes} in {js_url} "
+            f"({len(js_text)} bytes, {len(actions)} actions found: "
+            f"{sorted(actions)}). DRE renamed the action — add the new prefix "
+            f"to _SCREEN_ENDPOINTS[{name!r}]."
         )
 
-        # 3. Extract per-action apiVersion hashes from screen MVC JS files.
-        # Each callDataAction("ActionName", "url", "apiVersionHash", ...) in the JS
-        # contains the hash required for that specific server action.
-        fetched_js: dict[str, str] = {}  # url → text (avoid duplicate fetches)
-        for action_name, js_url in _SCREEN_JS_MAP.items():
-            if js_url not in fetched_js:
-                try:
-                    js_resp = self._request("GET", js_url)
-                    fetched_js[js_url] = js_resp.text
-                except Exception:
-                    logger.warning("Failed to fetch screen JS: %s", js_url)
-                    fetched_js[js_url] = ""
-
-            js_text = fetched_js[js_url]
-            # Pattern: callDataAction("ActionName", "endpoint/url", "apiHash", ...)
-            pattern = (
-                rf'callDataAction\s*\(\s*"{re.escape(action_name)}"\s*,\s*"[^"]+"\s*,\s*"([^"]+)"'
-            )
-            match = re.search(pattern, js_text)
-            if match:
-                self._api_versions[action_name] = match.group(1)
-                logger.info("API version for %s: %s", action_name, match.group(1)[:20])
-            else:
-                logger.warning("Could not extract apiVersion for %s", action_name)
-
-    def _action_name_from_url(self, url: str) -> str:
-        """Extract the DataAction name from a full endpoint URL."""
-        return url.rsplit("/", 1)[-1] if "/" in url else url
-
-    def _post(self, url: str, payload: dict) -> dict:
-        """POST JSON to an OutSystems endpoint with CSRF token."""
+    def _post(self, endpoint: str, payload: dict) -> dict:
+        """POST JSON to a resolved OutSystems endpoint with CSRF + version info."""
         self._request_count += 1
 
         # Refresh session every 100 requests
@@ -156,25 +189,38 @@ class DREHttpClient(HttpClient):
             logger.info("Refreshing session after %d requests", self._request_count)
             self._init_session()
 
-        headers = {}
-        if self._csrf_token:
-            headers["X-CSRFToken"] = self._csrf_token
-
-        # Inject version info with per-action apiVersion
-        action_name = self._action_name_from_url(url)
-        api_version = self._api_versions.get(action_name, "")
+        url, api_version = self._endpoints[endpoint]
 
         payload.setdefault("versionInfo", {})
-        if self._module_version:
-            payload["versionInfo"]["moduleVersion"] = self._module_version
-        if api_version:
-            payload["versionInfo"]["apiVersion"] = api_version
+        payload["versionInfo"]["moduleVersion"] = self._module_version
+        payload["versionInfo"]["apiVersion"] = api_version
 
         # Required since DRE OutSystems migration (2025)
         payload.setdefault("clientVariables", {})
 
-        resp = self._request("POST", url, json=payload, headers=headers)
-        return resp.json()
+        resp = self._request("POST", url, json=payload, headers={"X-CSRFToken": self._csrf_token})
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            # A stale apiVersion/CSRF makes OutSystems answer with an HTML error
+            # page.  Left alone this surfaces as JSONDecodeError deep in a
+            # per-date try/except and the run still ends green.
+            raise DREApiError(
+                f"{endpoint} returned {resp.headers.get('Content-Type', '?')} "
+                f"instead of JSON (HTTP {resp.status_code}): {resp.text[:200]!r}"
+            ) from exc
+
+        if not isinstance(data, dict):
+            raise DREApiError(f"{endpoint} returned {type(data).__name__}, expected an object")
+
+        if data.get("exception"):
+            exc_info = data["exception"]
+            raise DREApiError(
+                f"{endpoint} raised a server exception: "
+                f"{exc_info.get('name', '?')}/{exc_info.get('specificType', '?')} — "
+                f"{exc_info.get('message', '?')}"
+            )
+        return data
 
     @staticmethod
     def _parse_json_out(data: dict, key: str = "Json_Out") -> dict:
@@ -214,36 +260,39 @@ class DREHttpClient(HttpClient):
                 "Data": date_str,
             },
         }
-        result = self._post(_DRS_BY_DATE_URL, payload)
+        result = self._post(JOURNALS_BY_DATE, payload)
         data = result.get("data", {})
 
-        # New format (2025+): Elasticsearch response in Json_Out
+        # New format (2025+): Elasticsearch response in Json_Out.
+        # An empty `hits` list is a legitimate answer (holidays, Sundays);
+        # a response we cannot read at all is not — see below.
         es_data = self._parse_json_out(data)
         if es_data:
-            hits = es_data.get("hits", {}).get("hits", [])
             journals = []
-            for hit in hits:
+            for hit in es_data.get("hits", {}).get("hits", []):
                 source = hit.get("_source", {})
-                title = source.get("conteudoTitle", "")
                 journals.append(
                     {
                         "Id": source.get("dbId"),
                         "DiarioId": source.get("dbId"),
                         "Numero": source.get("numero", ""),
                         "DataPublicacao": source.get("dataPublicacao", ""),
-                        "conteudoTitle": title,
+                        "conteudoTitle": source.get("conteudoTitle", ""),
                     }
                 )
             return journals
 
         # Legacy format: structured SerieI.List
-        serie1 = data.get("SerieI", {})
-        if isinstance(serie1, dict) and serie1.get("List"):
-            return serie1["List"]
-        elif isinstance(serie1, list):
+        serie1 = data.get("SerieI")
+        if isinstance(serie1, dict):
+            return serie1.get("List", [])
+        if isinstance(serie1, list):
             return serie1
 
-        return []
+        raise DREApiError(
+            f"{JOURNALS_BY_DATE} for {date_str} returned neither Json_Out nor "
+            f"SerieI — keys: {sorted(data)}. DRE changed the response shape."
+        )
 
     def get_documents_by_journal(self, journal_id: int, is_serie1: bool = True) -> list[dict]:
         """Get all documents from a journal issue.
@@ -284,24 +333,27 @@ class DREHttpClient(HttpClient):
                 "DiplomaConteudoId": "",
             },
         }
-        result = self._post(_DOC_LIST_URL, payload)
+        result = self._post(DOCUMENTS_BY_JOURNAL, payload)
         data = result.get("data", {})
 
         # Try structured response: DetalheConteudo.List (current format)
         for key in ("DetalheConteudo", "DetalheConteudo2"):
-            container = data.get(key, {})
+            container = data.get(key)
             if isinstance(container, dict) and container.get("List"):
                 return container["List"]
-            elif isinstance(container, list):
+            if isinstance(container, list) and container:
                 return container
 
         # Elasticsearch response fallback
         es_data = self._parse_json_out(data)
         if es_data:
-            hits = es_data.get("hits", {}).get("hits", [])
-            return [hit.get("_source", {}) for hit in hits]
+            return [hit.get("_source", {}) for hit in es_data.get("hits", {}).get("hits", [])]
 
-        return []
+        raise DREApiError(
+            f"{DOCUMENTS_BY_JOURNAL} for journal {journal_id} returned no readable "
+            f"document list — keys: {sorted(data)}. A journal issue always has "
+            f"documents, so an unreadable response is a DRE change, not an empty day."
+        )
 
     def get_document_detail(self, diploma_id: str) -> dict:
         """Fetch full document detail including text.
@@ -325,8 +377,23 @@ class DREHttpClient(HttpClient):
                 "DiplomaConteudoId": "",
             },
         }
-        result = self._post(_DOC_DETAIL_URL, payload)
-        return result.get("data", {}).get("DetalheConteudo", {})
+        result = self._post(DOCUMENT_DETAIL, payload)
+        detail = result.get("data", {}).get("DetalheConteudo", {})
+
+        # DRE answers an unrecognised input with a fully-populated *default*
+        # record — Id 0, empty Numero, DataPublicacao 1900-01-01 — rather than
+        # an error.  Left alone that becomes a committed law with no title,
+        # no date and no text, so treat it as the API break it is.
+        if not isinstance(detail, dict) or not (
+            str(detail.get("Numero", "")).strip() or str(detail.get("ELI", "")).strip()
+        ):
+            raise DREApiError(
+                f"{DOCUMENT_DETAIL} returned an empty record for diploma_id={diploma_id} "
+                f"(Id={detail.get('Id') if isinstance(detail, dict) else detail!r}). "
+                f"The screen no longer accepts DipLegisId as its input variable — "
+                f"see docs/pt-dre-api.md."
+            )
+        return detail
 
     def get_text(self, diploma_id: str) -> bytes:
         """Fetch the full text of a document.

--- a/src/legalize/fetcher/pt/client.py
+++ b/src/legalize/fetcher/pt/client.py
@@ -61,6 +61,9 @@ _SCREEN_ENDPOINTS: dict[str, tuple[str, tuple[str, ...]]] = {
     ),
 }
 
+# Document sitemap path: /dr/detalhe/{tipo}/{key}
+_SITEMAP_REF_RE = re.compile(r"/dr/detalhe/([^/]+)/([^/?#]+)")
+
 # callDataAction("ActionName", "screenservices/...", "apiVersionHash", ...)
 _CALL_DATA_ACTION_RE = re.compile(
     r'callDataAction\s*\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"'
@@ -74,6 +77,21 @@ class DREApiError(RuntimeError):
     the daily run in red rather than recording a silent "no new norms" day
     and advancing the state past legislation we never saw.
     """
+
+
+def _split_sitemap_ref(ref: str) -> tuple[str, str]:
+    """Split a DRE sitemap path into the detail screen's (Tipo, Key) inputs.
+
+    ``/dr/detalhe/decreto-lei/169-2026-1159106557`` → ``("decreto-lei",
+    "169-2026-1159106557")``.  Accepts a full URL as well as a bare path.
+    """
+    match = _SITEMAP_REF_RE.search(ref or "")
+    if not match:
+        raise DREApiError(
+            f"Cannot read a document reference out of {ref!r}. Expected a DRE "
+            f"sitemap path like /dr/detalhe/decreto-lei/169-2026-1159106557."
+        )
+    return match.group(1), match.group(2)
 
 
 def _nested_get(d: dict, *keys: str, default: str = "") -> str:
@@ -355,22 +373,31 @@ class DREHttpClient(HttpClient):
             f"documents, so an unreadable response is a DRE change, not an empty day."
         )
 
-    def get_document_detail(self, diploma_id: str) -> dict:
+    def get_document_detail(self, ref: str) -> dict:
         """Fetch full document detail including text.
 
         Args:
-            diploma_id: Internal document legislation ID (DipLegisId).
+            ref: The document's sitemap path as published in the document
+                list, e.g. ``/dr/detalhe/decreto-lei/169-2026-1159106557``.
+                The detail screen is URL-driven: its inputs are the *type*
+                and *key* segments of that path, not a raw id.
 
         Returns:
             Dict with document details including Texto/TextoFormatado.
             Field names follow the new DRE API (2025+):
             TipoDiploma, Emissor, ELI, Vigencia, etc.
         """
+        tipo, key = _split_sitemap_ref(ref)
         payload = {
             "viewName": "Legislacao_Conteudos.Conteudo_Detalhe",
             "screenData": {
                 "variables": {
-                    "DipLegisId": str(diploma_id),
+                    "Tipo": tipo,
+                    "_tipoInDataFetchStatus": 1,
+                    "Key": key,
+                    "_keyInDataFetchStatus": 1,
+                    "ParteId": "0",
+                    "_parteIdInDataFetchStatus": 1,
                 },
             },
             "clientVariables": {
@@ -388,33 +415,32 @@ class DREHttpClient(HttpClient):
             str(detail.get("Numero", "")).strip() or str(detail.get("ELI", "")).strip()
         ):
             raise DREApiError(
-                f"{DOCUMENT_DETAIL} returned an empty record for diploma_id={diploma_id} "
+                f"{DOCUMENT_DETAIL} returned an empty record for {ref} "
                 f"(Id={detail.get('Id') if isinstance(detail, dict) else detail!r}). "
-                f"The screen no longer accepts DipLegisId as its input variable — "
-                f"see docs/pt-dre-api.md."
+                f"The screen's Tipo/Key inputs no longer resolve — see docs/pt-dre-api.md."
             )
         return detail
 
-    def get_text(self, diploma_id: str) -> bytes:
-        """Fetch the full text of a document.
+    def get_text(self, ref: str) -> bytes:
+        """Fetch the full text of a document by its sitemap path.
 
         Returns HTML text as UTF-8 bytes, compatible with DRETextParser.
         """
-        detail = self.get_document_detail(diploma_id)
+        detail = self.get_document_detail(ref)
         text = detail.get("Texto", "").strip()
         if not text:
             text = detail.get("TextoFormatado", "").strip()
         if not text:
-            raise ValueError(f"No text found for diploma_id={diploma_id}")
+            raise ValueError(f"No text found for {ref}")
         return text.encode("utf-8")
 
-    def get_metadata(self, diploma_id: str) -> bytes:
-        """Fetch metadata for a document.
+    def get_metadata(self, ref: str) -> bytes:
+        """Fetch metadata for a document by its sitemap path.
 
         Returns JSON bytes compatible with DREMetadataParser.
         Handles both legacy and new (2025+) field names from the API.
         """
-        detail = self.get_document_detail(diploma_id)
+        detail = self.get_document_detail(ref)
 
         # Vigencia: "NAO_VIGENTE" means repealed
         vigencia = detail.get("Vigencia", "")
@@ -442,7 +468,7 @@ class DREHttpClient(HttpClient):
         )
 
         meta = {
-            "claint": detail.get("ConteudoId", detail.get("Id", diploma_id)),
+            "claint": detail.get("ConteudoId", detail.get("Id", "")),
             "doc_type": doc_type,
             "number": detail.get("Numero", "").strip(),
             "emiting_body": emiting_body,

--- a/src/legalize/fetcher/pt/daily.py
+++ b/src/legalize/fetcher/pt/daily.py
@@ -84,6 +84,9 @@ def _discover_daily_http(client, target_date: date) -> list[dict]:
                     documents.append(
                         {
                             "diploma_id": str(diploma_id),
+                            # The detail screen is URL-driven, so the fetch
+                            # needs the document's own sitemap path, not its id.
+                            "ref": doc.get("LinkSitemap", ""),
                             "doc_type": doc_type,
                             "title": doc.get("Sumario", doc_type),
                         }
@@ -162,10 +165,11 @@ def daily(
                     continue
 
                 try:
-                    meta_data = client.get_metadata(diploma_id)
+                    ref = doc_info["ref"]
+                    meta_data = client.get_metadata(ref)
                     metadata = meta_parser.parse(meta_data, diploma_id)
 
-                    text_data = client.get_text(diploma_id)
+                    text_data = client.get_text(ref)
                     blocks = text_parser.parse_text_with_date(
                         text_data, metadata.publication_date, metadata.identifier
                     )
@@ -197,6 +201,12 @@ def daily(
                         commits_created += 1
                         console.print(f"    [green]✓[/green] {info.subject}")
 
+                except DREApiError:
+                    # Same reasoning as discovery: a contract break hits every
+                    # remaining document, so collecting it per document would
+                    # walk the whole day and still exit 0.
+                    logger.exception("DRE API contract broken — aborting daily run")
+                    raise
                 except Exception as e:
                     msg = f"Error processing diploma_id={diploma_id}: {e}"
                     logger.exception(msg)

--- a/src/legalize/fetcher/pt/daily.py
+++ b/src/legalize/fetcher/pt/daily.py
@@ -98,7 +98,7 @@ def daily(
     dry_run: bool = False,
 ) -> int:
     """Daily processing for Portugal via HTTP (no SQLite needed)."""
-    from legalize.fetcher.pt.client import DREHttpClient
+    from legalize.fetcher.pt.client import DREApiError, DREHttpClient
     from legalize.fetcher.pt.parser import DREMetadataParser, DRETextParser
 
     cc = config.get_country("pt")
@@ -133,9 +133,15 @@ def daily(
 
             try:
                 documents = _discover_daily_http(client, current_date)
+            except DREApiError:
+                # A broken DRE contract is not a bad day, it is a broken
+                # client: every remaining date would fail the same way and
+                # record itself as "no new norms". Abort loudly instead.
+                logger.exception("DRE API contract broken — aborting daily run")
+                raise
             except Exception:
                 msg = f"Error discovering changes for {current_date}"
-                logger.error(msg, exc_info=True)
+                logger.exception(msg)
                 errors.append(msg)
                 continue
 
@@ -193,7 +199,7 @@ def daily(
 
                 except Exception as e:
                     msg = f"Error processing diploma_id={diploma_id}: {e}"
-                    logger.error(msg, exc_info=True)
+                    logger.exception(msg)
                     errors.append(msg)
 
             state.last_summary_date = current_date

--- a/tests/test_daily_pt.py
+++ b/tests/test_daily_pt.py
@@ -259,7 +259,12 @@ class TestDailyPTOrchestration:
         config = self._make_config(tmp_path)
 
         mock_discover.return_value = [
-            {"diploma_id": "100001", "doc_type": "LEI", "title": "Bad law"},
+            {
+                "diploma_id": "100001",
+                "ref": "/dr/detalhe/lei/1-2026-100001",
+                "doc_type": "LEI",
+                "title": "Bad law",
+            },
         ]
 
         mock_client = mock_client_cls.create.return_value

--- a/tests/test_parser_dre.py
+++ b/tests/test_parser_dre.py
@@ -616,18 +616,31 @@ class _FakeHttpClient:
         return [{"Id": 1}]
 
     def get_documents_by_journal(self, journal_id, is_serie1=True):
+        # LinkSitemap mirrors the real API: the detail screen is URL-driven,
+        # so the daily fetches by sitemap path rather than by id.
         return [
-            {"DiplomaConteudoId": d[0], "TipoActo": d[1], "Sumario": f"{d[1]} {d[2]}"}
+            {
+                "DiplomaConteudoId": d[0],
+                "TipoActo": d[1],
+                "Sumario": f"{d[1]} {d[2]}",
+                "LinkSitemap": f"/dr/detalhe/lei/{d[0]}",
+            }
             for d in self._docs
         ]
 
-    def get_text(self, diploma_id):
+    @staticmethod
+    def _id_from_ref(ref):
+        return ref.rsplit("/", 1)[-1]
+
+    def get_text(self, ref):
+        diploma_id = self._id_from_ref(ref)
         for d in self._docs:
             if d[0] == diploma_id:
                 return d[3].encode("utf-8")
-        raise ValueError(f"Not found: {diploma_id}")
+        raise ValueError(f"Not found: {ref}")
 
-    def get_metadata(self, diploma_id):
+    def get_metadata(self, ref):
+        diploma_id = self._id_from_ref(ref)
         for d in self._docs:
             if d[0] == diploma_id:
                 meta = {

--- a/tests/test_pt_client_apiversion.py
+++ b/tests/test_pt_client_apiversion.py
@@ -1,0 +1,332 @@
+"""Tests for DRE OutSystems endpoint discovery and loud failure (Portugal).
+
+The daily run against diariodarepublica.pt broke in May 2026 when DRE
+redeployed and renamed its screen actions.  The client kept warning
+"Could not extract apiVersion", posted to the old URL, got an HTML error
+page back, and the job still finished green with zero commits.
+
+These tests pin the two halves of the fix:
+  1. endpoint URL + apiVersion are read from the screen JS at runtime, and a
+     renamed action is still found (or raises if it cannot be);
+  2. anything that is not a readable JSON answer raises DREApiError instead
+     of degrading to an empty result.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from legalize.fetcher.pt.client import (
+    DOCUMENT_DETAIL,
+    JOURNALS_BY_DATE,
+    DREApiError,
+    DREHttpClient,
+)
+from legalize.fetcher.pt.daily import daily
+
+# Real shape of dr.Home.home.mvc.js after the May 2026 DRE redeploy: the
+# action gained an "AndCheckUserLog" suffix and a fresh apiVersion hash.
+_HOME_JS_RENAMED = (
+    "var callContext = controller.callContext(callContext);\n"
+    'return controller.callDataAction("DataActionGetContagens", '
+    '"screenservices/dr/Home/home/DataActionGetContagens", "BdsM+VO38pdcAF3wnMGdpQ", '
+    "function (b) {});\n"
+    'return controller.callDataAction("DataActionGetDRByDataCalendarioAndCheckUserLog", '
+    '"screenservices/dr/Home/home/DataActionGetDRByDataCalendarioAndCheckUserLog", '
+    '"k+86ytikYIT6brie_oLQTQ", function (b) {});\n'
+)
+
+
+def _html_response(status: int = 200) -> requests.Response:
+    """A real Response carrying an OutSystems HTML error page."""
+    resp = requests.Response()
+    resp.status_code = status
+    resp._content = b"\n<!DOCTYPE html>\n<html><body>Ocorreu um erro</body></html>"
+    resp.headers["Content-Type"] = "text/html; charset=utf-8"
+    return resp
+
+
+def _json_response(payload: dict) -> requests.Response:
+    import json as _json
+
+    resp = requests.Response()
+    resp.status_code = 200
+    resp._content = _json.dumps(payload).encode()
+    resp.headers["Content-Type"] = "application/json; charset=utf-8"
+    return resp
+
+
+def _client() -> DREHttpClient:
+    """A client with the network handshake skipped."""
+    with patch.object(DREHttpClient, "_init_session"):
+        client = DREHttpClient(timeout=5)
+    client._csrf_token = "csrf-token"
+    client._module_version = "9DeZ4j9NYEpfCiXfe3gDLw"
+    client._endpoints = {
+        name: (f"https://diariodarepublica.pt/dr/screenservices/{name}", "hash")
+        for name in (JOURNALS_BY_DATE, DOCUMENT_DETAIL, "documents_by_journal")
+    }
+    return client
+
+
+# ─────────────────────────────────────────────
+# Endpoint discovery
+# ─────────────────────────────────────────────
+
+
+class TestResolveEndpoint:
+    def test_finds_renamed_action_by_prefix(self):
+        """A suffix added to the action name must not break discovery."""
+        client = _client()
+
+        url, api_version = client._resolve_endpoint(
+            JOURNALS_BY_DATE, _HOME_JS_RENAMED, "home.mvc.js", ("DataActionGetDRByDataCalendario",)
+        )
+
+        assert url.endswith(
+            "/screenservices/dr/Home/home/DataActionGetDRByDataCalendarioAndCheckUserLog"
+        )
+        assert api_version == "k+86ytikYIT6brie_oLQTQ"
+
+    def test_missing_action_raises_with_diagnostics(self):
+        """A wholesale rename must fail loudly and name what it did find."""
+        client = _client()
+
+        with pytest.raises(DREApiError) as exc:
+            client._resolve_endpoint(
+                JOURNALS_BY_DATE, _HOME_JS_RENAMED, "home.mvc.js", ("DataActionGetSomethingElse",)
+            )
+
+        message = str(exc.value)
+        assert "DataActionGetSomethingElse" in message
+        assert "DataActionGetContagens" in message  # lists what the JS does contain
+
+    def test_empty_js_raises(self):
+        """A JS file served as an error page yields no actions at all."""
+        client = _client()
+
+        with pytest.raises(DREApiError):
+            client._resolve_endpoint(
+                JOURNALS_BY_DATE, "", "home.mvc.js", ("DataActionGetDRByDataCalendario",)
+            )
+
+
+# ─────────────────────────────────────────────
+# _post: HTML instead of JSON
+# ─────────────────────────────────────────────
+
+
+class TestPostFailsLoudly:
+    def test_html_instead_of_json_raises(self):
+        """The exact May 2026 failure: stale apiVersion → HTML error page."""
+        client = _client()
+
+        with (
+            patch.object(client, "_request", return_value=_html_response()),
+            pytest.raises(DREApiError) as exc,
+        ):
+            client._post(JOURNALS_BY_DATE, {})
+
+        message = str(exc.value)
+        assert "instead of JSON" in message
+        assert "text/html" in message
+
+    def test_server_exception_raises(self):
+        """OutSystems answers 200 + JSON with an `exception` field."""
+        client = _client()
+        payload = {
+            "data": {},
+            "exception": {
+                "name": "ServerException",
+                "specificType": "System.InvalidOperationException",
+                "message": "No role validation found",
+            },
+        }
+
+        with (
+            patch.object(client, "_request", return_value=_json_response(payload)),
+            pytest.raises(DREApiError, match="No role validation found"),
+        ):
+            client._post(JOURNALS_BY_DATE, {})
+
+    def test_apiversion_and_module_version_are_sent(self):
+        client = _client()
+        client._endpoints[JOURNALS_BY_DATE] = ("https://dre.test/action", "the-hash")
+        request = MagicMock(return_value=_json_response({"data": {}}))
+
+        with patch.object(client, "_request", request):
+            client._post(JOURNALS_BY_DATE, {})
+
+        sent = request.call_args.kwargs["json"]
+        assert sent["versionInfo"]["apiVersion"] == "the-hash"
+        assert sent["versionInfo"]["moduleVersion"] == "9DeZ4j9NYEpfCiXfe3gDLw"
+        assert request.call_args.kwargs["headers"]["X-CSRFToken"] == "csrf-token"
+
+
+# ─────────────────────────────────────────────
+# get_journals_by_date: empty day vs broken API
+# ─────────────────────────────────────────────
+
+
+class TestJournalsByDate:
+    def test_empty_hits_is_a_legitimate_empty_day(self):
+        """Sundays and holidays really do publish nothing — no false alarm."""
+        client = _client()
+        payload = {"data": {"Json_Out": '{"hits": {"hits": []}}'}}
+
+        with patch.object(client, "_request", return_value=_json_response(payload)):
+            assert client.get_journals_by_date("2026-08-16") == []
+
+    def test_hits_are_mapped(self):
+        client = _client()
+        payload = {
+            "data": {
+                "Json_Out": (
+                    '{"hits": {"hits": [{"_source": {"dbId": 1159106555, "numero": "159",'
+                    ' "dataPublicacao": "2026-08-18",'
+                    ' "conteudoTitle": "Di\\u00e1rio da Rep\\u00fablica n.\\u00ba 159/2026, S\\u00e9rie I de 2026-08-18"}}]}}'
+                )
+            }
+        }
+
+        with patch.object(client, "_request", return_value=_json_response(payload)):
+            journals = client.get_journals_by_date("2026-08-18")
+
+        assert len(journals) == 1
+        assert journals[0]["Id"] == 1159106555
+        assert "Série I" in journals[0]["conteudoTitle"]
+
+    def test_unreadable_shape_raises(self):
+        """Neither Json_Out nor SerieI means DRE changed the contract."""
+        client = _client()
+        payload = {"data": {"SomethingNew": {"List": []}}}
+
+        with (
+            patch.object(client, "_request", return_value=_json_response(payload)),
+            pytest.raises(DREApiError, match="response shape"),
+        ):
+            client.get_journals_by_date("2026-08-18")
+
+
+# ─────────────────────────────────────────────
+# get_document_detail: default record is not a document
+# ─────────────────────────────────────────────
+
+
+class TestDocumentDetail:
+    def test_default_record_raises(self):
+        """DRE answers an unknown input with Id 0 / 1900-01-01, not an error."""
+        client = _client()
+        payload = {
+            "data": {
+                "DetalheConteudo": {
+                    "Id": 0,
+                    "Numero": "",
+                    "ELI": "",
+                    "DataPublicacao": "1900-01-01",
+                }
+            }
+        }
+
+        with (
+            patch.object(client, "_request", return_value=_json_response(payload)),
+            pytest.raises(DREApiError, match="empty record"),
+        ):
+            client.get_document_detail("1159106557")
+
+    def test_real_record_passes_through(self):
+        client = _client()
+        payload = {
+            "data": {
+                "DetalheConteudo": {
+                    "Id": 1159106557,
+                    "Numero": "169/2026",
+                    "ELI": "https://data.dre.pt/eli/dec-lei/169/2026",
+                    "DataPublicacao": "2026-08-18",
+                    "Texto": "<p>Artigo 1.º</p>",
+                }
+            }
+        }
+
+        with patch.object(client, "_request", return_value=_json_response(payload)):
+            detail = client.get_document_detail("1159106557")
+
+        assert detail["Numero"] == "169/2026"
+
+
+# ─────────────────────────────────────────────
+# daily(): red job, state untouched
+# ─────────────────────────────────────────────
+
+
+class TestDailyAbortsOnApiBreak:
+    def _make_config(self, tmp_path: Path):
+        from legalize.config import Config, CountryConfig, GitConfig
+
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        subprocess.run(["git", "init"], cwd=repo_path, capture_output=True, check=False)
+
+        return Config(
+            git=GitConfig(committer_name="Legalize", committer_email="test@test.com"),
+            countries={
+                "pt": CountryConfig(
+                    repo_path=str(repo_path),
+                    data_dir=str(tmp_path / "data"),
+                    state_path=str(tmp_path / "state" / "state.json"),
+                    source={},
+                )
+            },
+        )
+
+    @patch("legalize.fetcher.pt.client.DREHttpClient", autospec=True)
+    @patch("legalize.fetcher.pt.daily._discover_daily_http")
+    def test_api_break_raises_instead_of_zero_commits(
+        self, mock_discover, mock_client_cls, tmp_path
+    ):
+        """The regression that cost three months: 0 commits used to exit green."""
+        config = self._make_config(tmp_path)
+        mock_discover.side_effect = DREApiError("returned text/html instead of JSON")
+
+        mock_client = mock_client_cls.create.return_value
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(DREApiError):
+            daily(config, target_date=date(2026, 8, 10))
+
+    @patch("legalize.fetcher.pt.client.DREHttpClient", autospec=True)
+    @patch("legalize.fetcher.pt.daily._discover_daily_http")
+    def test_api_break_does_not_advance_state(self, mock_discover, mock_client_cls, tmp_path):
+        """A day we could not read must stay unprocessed, not be marked done."""
+        config = self._make_config(tmp_path)
+        mock_discover.side_effect = DREApiError("returned text/html instead of JSON")
+
+        mock_client = mock_client_cls.create.return_value
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(DREApiError):
+            daily(config, target_date=date(2026, 8, 10))
+
+        state_path = Path(config.get_country("pt").state_path)
+        assert not state_path.exists() or "2026-08-10" not in state_path.read_text()
+
+    @patch("legalize.fetcher.pt.client.DREHttpClient", autospec=True)
+    @patch("legalize.fetcher.pt.daily._discover_daily_http")
+    def test_transient_error_still_continues(self, mock_discover, mock_client_cls, tmp_path):
+        """Non-contract errors keep the old per-date tolerance."""
+        config = self._make_config(tmp_path)
+        mock_discover.side_effect = RuntimeError("connection reset")
+
+        mock_client = mock_client_cls.create.return_value
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        assert daily(config, target_date=date(2026, 8, 10)) == 0

--- a/tests/test_pt_client_apiversion.py
+++ b/tests/test_pt_client_apiversion.py
@@ -27,8 +27,9 @@ from legalize.fetcher.pt.client import (
     JOURNALS_BY_DATE,
     DREApiError,
     DREHttpClient,
+    _split_sitemap_ref,
 )
-from legalize.fetcher.pt.daily import daily
+from legalize.fetcher.pt.daily import _discover_daily_http, daily
 
 # Real shape of dr.Home.home.mvc.js after the May 2026 DRE redeploy: the
 # action gained an "AndCheckUserLog" suffix and a fresh apiVersion hash.
@@ -215,6 +216,73 @@ class TestJournalsByDate:
 
 
 # ─────────────────────────────────────────────
+# The detail screen is URL-driven
+# ─────────────────────────────────────────────
+
+
+class TestSitemapRef:
+    """The detail screen takes the URL's type and key, never a raw id."""
+
+    def test_splits_a_sitemap_path(self):
+        assert _split_sitemap_ref("/dr/detalhe/decreto-lei/169-2026-1159106557") == (
+            "decreto-lei",
+            "169-2026-1159106557",
+        )
+
+    def test_splits_a_full_url(self):
+        assert _split_sitemap_ref(
+            "https://diariodarepublica.pt/dr/detalhe/portaria/349-2026-1159106558"
+        ) == ("portaria", "349-2026-1159106558")
+
+    @pytest.mark.parametrize("ref", ["", "1159106557", "/dr/home", None])
+    def test_unusable_reference_raises(self, ref):
+        with pytest.raises(DREApiError, match="document reference"):
+            _split_sitemap_ref(ref)
+
+    def test_detail_posts_tipo_and_key(self):
+        """Regression: DipLegisId stopped being an input in the May 2026 deploy."""
+        client = _client()
+        request = MagicMock(
+            return_value=_json_response(
+                {"data": {"DetalheConteudo": {"Id": 1159106557, "Numero": "169/2026"}}}
+            )
+        )
+
+        with patch.object(client, "_request", request):
+            client.get_document_detail("/dr/detalhe/decreto-lei/169-2026-1159106557")
+
+        variables = request.call_args.kwargs["json"]["screenData"]["variables"]
+        assert variables["Tipo"] == "decreto-lei"
+        assert variables["Key"] == "169-2026-1159106557"
+        assert variables["_tipoInDataFetchStatus"] == 1
+        assert variables["_keyInDataFetchStatus"] == 1
+        assert "DipLegisId" not in variables
+
+
+class TestDiscoveryCarriesTheReference:
+    def test_link_sitemap_becomes_the_ref(self):
+        """Discovery must hand the detail fetch the document's own URL."""
+        client = MagicMock()
+        client.get_journals_by_date.return_value = [
+            {"Id": "1159106555", "conteudoTitle": "Diário da República n.º 159/2026, Série I"}
+        ]
+        client.get_documents_by_journal.return_value = [
+            {
+                "TipoDiploma": "Decreto-Lei",
+                "DiplomaLegisId": "1159106557",
+                "Sumario": "Altera o Decreto-Lei n.º 252/2007",
+                "LinkSitemap": "/dr/detalhe/decreto-lei/169-2026-1159106557",
+            }
+        ]
+
+        found = _discover_daily_http(client, date(2026, 8, 18))
+
+        assert len(found) == 1
+        assert found[0]["ref"] == "/dr/detalhe/decreto-lei/169-2026-1159106557"
+        assert found[0]["diploma_id"] == "1159106557"
+
+
+# ─────────────────────────────────────────────
 # get_document_detail: default record is not a document
 # ─────────────────────────────────────────────
 
@@ -238,7 +306,7 @@ class TestDocumentDetail:
             patch.object(client, "_request", return_value=_json_response(payload)),
             pytest.raises(DREApiError, match="empty record"),
         ):
-            client.get_document_detail("1159106557")
+            client.get_document_detail("/dr/detalhe/decreto-lei/169-2026-1159106557")
 
     def test_real_record_passes_through(self):
         client = _client()
@@ -255,7 +323,7 @@ class TestDocumentDetail:
         }
 
         with patch.object(client, "_request", return_value=_json_response(payload)):
-            detail = client.get_document_detail("1159106557")
+            detail = client.get_document_detail("/dr/detalhe/decreto-lei/169-2026-1159106557")
 
         assert detail["Numero"] == "169/2026"
 
@@ -317,6 +385,30 @@ class TestDailyAbortsOnApiBreak:
 
         state_path = Path(config.get_country("pt").state_path)
         assert not state_path.exists() or "2026-08-10" not in state_path.read_text()
+
+    @patch("legalize.fetcher.pt.client.DREHttpClient", autospec=True)
+    @patch("legalize.fetcher.pt.daily._discover_daily_http")
+    def test_api_break_while_fetching_a_document_aborts(
+        self, mock_discover, mock_client_cls, tmp_path
+    ):
+        """Discovery can succeed and the *fetch* still hit a broken contract."""
+        config = self._make_config(tmp_path)
+        mock_discover.return_value = [
+            {
+                "diploma_id": "1159106557",
+                "ref": "/dr/detalhe/decreto-lei/169-2026-1159106557",
+                "doc_type": "DECRETO-LEI",
+                "title": "Altera o Decreto-Lei n.º 252/2007",
+            }
+        ]
+
+        mock_client = mock_client_cls.create.return_value
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get_metadata.side_effect = DREApiError("returned an empty record")
+
+        with pytest.raises(DREApiError):
+            daily(config, target_date=date(2026, 8, 18))
 
     @patch("legalize.fetcher.pt.client.DREHttpClient", autospec=True)
     @patch("legalize.fetcher.pt.daily._discover_daily_http")


### PR DESCRIPTION
## Why

The Portuguese daily has been finding nothing since DRE's May 2026 redeploy — and **exiting green while doing it**. Logs showed `Could not extract apiVersion for …` followed by `JSONDecodeError: Expecting value: line 2 column 1`, and the job still returned 0.

DRE renamed the actions the fetcher drives, and changed how the detail screen is addressed:

| Endpoint | Before | Today |
|---|---|---|
| journals by date | `DataActionGetDRByDataCalendario` | `DataActionGetDRByDataCalendarioAndCheckUserLog` |
| documents by journal | `DataActionGetDadosAndApplicationSettings` | unchanged |
| document detail | `DataActionGetConteudoDataAndApplicationSettings`, input `DipLegisId` | `DataActionGetAllConteudoDetalheData`, inputs `Tipo` + `Key` |

The client looked actions up by exact name, warned when it missed, then POSTed to the old URL with no `apiVersion`. OutSystems answers that with an HTML error page; `resp.json()` raised inside a per-date `try/except`; the date was recorded as "no new norms" and the state advanced past it.

**pt runs end to end again.** Two commits: endpoint discovery + loud failure, then the detail contract.

## 1 — Endpoints are discovered, not hardcoded

`_resolve_endpoint()` reads both the URL path and the `apiVersion` hash out of the screen's MVC JavaScript (`callDataAction("Name", "path", "hash", …)`), matching the action by **prefix** so a renamed suffix is absorbed automatically. A wholesale rename raises with the full list of actions the JS does contain, so adding a prefix is a one-line fix.

## 2 — The detail screen is URL-driven

`DataActionGetAllConteudoDetalheData` never took an id. Its inputs are the segments of its own address, which OutSystems marks with an `In` suffix in the screen model:

```js
new M.modelClass().variables  →  tipoIn, keyIn, parteIdIn
```

posted as `Tipo` / `Key` / `ParteId`. Both segments are already in hand — the document list returns a `LinkSitemap` for every document (`/dr/detalhe/decreto-lei/169-2026-1159106557`) — so `_split_sitemap_ref()` splits it and `get_text()`/`get_metadata()` take that path as their reference. The daily carries it through `doc_info["ref"]`.

Nothing is reconstructed from `TipoDiploma` + `Numero` + id: a Portaria numbered `349/2026/1` does not map to its slug the way you would guess.

## 3 — Nothing fails quietly any more

Everything that used to degrade to an empty result raises `DREApiError`:

- missing CSRF token, module version, or screen action;
- a response body that is not JSON (the exact May failure);
- a JSON body carrying an OutSystems `exception` field;
- a response shape with neither `Json_Out` nor `SerieI`;
- an unreadable document reference;
- a document detail record with no `Numero` and no `ELI` — DRE answers an unrecognised input with a *default record* (`Id: 0`, `DataPublicacao: "1900-01-01"`) rather than an error, and that would have been committed as a law with no title, date or text.

`daily()` lets `DREApiError` propagate from **both** discovery and the per-document fetch, instead of collecting it. A broken contract fails identically for every remaining day and every remaining document, so continuing only manufactures silent "nothing published" days. The CLI does not swallow it → **exit 1, red job**.

An empty `hits` list is still a legitimate empty day (Sundays, holidays) — no false alarms. Transient errors keep their per-date and per-document tolerance.

## Verified live against DRE (2026-08-20)

```
Resolved journals_by_date     → DataActionGetDRByDataCalendarioAndCheckUserLog
Resolved documents_by_journal → DataActionGetDadosAndApplicationSettings
Resolved document_detail      → DataActionGetAllConteudoDetalheData

2026-08-18  DRE-DL-169-2026    decreto-lei  6 blocks  Altera o Decreto-Lei n.º 252/2007…
            DRE-P-349-2026-1   portaria     6 blocks  Aprova a delimitação dos perímetros…
2026-08-14  DRE-P-345-2026-1   portaria     6 blocks  Aprova a delimitação do perímetro…
```

Discovery through parsed blocks, against the live API. No commits created, nothing pushed to `legalize-pt`.

## Tests

`tests/test_pt_client_apiversion.py` — 21 tests:

- renamed action found by prefix; missing action raises with diagnostics; empty JS raises;
- **HTML instead of JSON raises `DREApiError`** (a real `requests.Response` with an HTML body, not a stubbed `.json()`);
- server `exception` field raises; `apiVersion`/`moduleVersion`/CSRF actually sent;
- sitemap path and full URL both split; unusable references raise;
- **detail posts `Tipo`/`Key`, never `DipLegisId`**; discovery carries `LinkSitemap` into `ref`;
- empty `hits` is a legitimate empty day; unreadable shape raises;
- default detail record raises; real record passes through;
- **`daily()` raises instead of returning 0** — from discovery *and* from a document fetch — and **does not advance state** past the unread day;
- transient errors still continue.

Two fixtures predated the reference and fetched by bare id; the fake client in `test_parser_dre.py` now serves `LinkSitemap` and resolves by path, mirroring the real contract.

Full suite: `1724 passed, 27 skipped`.

## Backfill

This recovers **forward only**. Closing the ~3-month gap needs an explicit `--date` per day: `resolve_dates_to_process` clamps automatic lookback to `MAX_LOOKBACK_DAYS = 10` (`state/store.py:19`), so the cron can never walk back that far. The fetch path itself now works, so a scripted day-by-day backfill outside the cron is possible — deliberately not done here.

## Note on CI

The `lint` job fails on every branch in this repo right now: `ci.yml` runs `pip install ruff` unpinned and ruff 0.16.3 widened its default rules (466 pre-existing errors on `main`). PR #82 pins it. Every line added here is clean under both the pinned 0.15.8 and 0.16.3.

`docs/pt-dre-api.md` records the whole contract, how it broke, and the `requirejs` trick that recovers a screen's input names — so the next DRE deploy is a five-minute diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)