### PR TITLE
fix(fr): take the daily scope from the repo and apply increments over the dump

### DIFF
--- a/src/legalize/fetcher/fr/daily.py
+++ b/src/legalize/fetcher/fr/daily.py
@@ -4,11 +4,17 @@ Downloads LEGI daily increments from DILA and processes modified texts.
 Increments are tar.gz files published Mon-Sat at:
   https://echanges.dila.gouv.fr/OPENDATA/LEGI/LEGI_YYYYMMDD-HHMMSS.tar.gz
 
-Unlike Spain (BOE), France does NOT have a reform/404 problem:
-LEGI increments contain the updated consolidated texts directly.
-When a law is reformed, the increment delivers the modified LEGITEXT
-XML with the new article versions already merged. There is no need
-to resolve "affected norms" from a reforming disposition.
+Unlike Spain (BOE), France does NOT have a reform/404 problem: the
+increment names the modified LEGITEXTs directly, so there is no need to
+resolve "affected norms" from a reforming disposition.
+
+An increment is a delta, not a standalone text. It carries the modified
+struct plus the article and section files that changed — measured on
+LEGI_20260819, 64% of the sections a modified code references were absent,
+and 83% of the articles reachable through the ones present. It is applied
+*over* the consolidated dump
+(Freemium_legi_global_*.tar.gz), which supplies everything else; without
+that dump on disk a rendered text would be a shell of headings.
 """
 
 from __future__ import annotations
@@ -39,6 +45,11 @@ DILA_LEGI_URL = "https://echanges.dila.gouv.fr/OPENDATA/LEGI/"
 USER_AGENT = "legalize-bot/1.0 (+https://github.com/legalize-dev/legalize)"
 
 _INCREMENT_RE = re.compile(r'href="(LEGI_(\d{8}-\d{6})\.tar\.gz)"')
+
+# DILA wraps every increment in a YYYYMMDD-HHMMSS/ directory; the global dump
+# starts at legi/. Stripping that root is what makes an increment land on top
+# of the dump it patches instead of in a sibling tree nobody reads.
+_INCREMENT_ROOT_RE = re.compile(r"^\d{8}-\d{6}/")
 
 
 def _list_increments(session: requests.Session) -> list[tuple[str, str]]:
@@ -81,25 +92,47 @@ def _download_increment(session: requests.Session, url: str, dest_path: Path) ->
 
 
 def _extract_increment(tar_path: Path, legi_dir: Path) -> set[str]:
-    """Extract increment tar.gz to legi_dir and return discovered LEGITEXT IDs.
+    """Extract increment tar.gz over the dump and return modified LEGITEXT IDs.
 
-    Only extracts once (to legi_dir, merging into the existing dump).
+    The tar's own root (``YYYYMMDD-HHMMSS/``) is dropped so its files overwrite
+    the dump entries they replace. Extracted verbatim they landed in
+    ``{legi_dir}/20260819-222711/legi/global/...``, which LEGIClient never
+    looks at — so the client kept reading the pre-increment XML and every
+    rendered text came out byte-identical to the one already committed.
+
     Scans tar members to find modified LEGITEXT struct files — this is
     much faster than extracting to a separate dir and doing rglob.
     """
     legitext_ids: set[str] = set()
+    members: list[tarfile.TarInfo] = []
 
     with tarfile.open(tar_path, "r:gz") as tar:
         for member in tar.getmembers():
+            member.name = _INCREMENT_ROOT_RE.sub("", member.name, count=1)
+            if not member.name:
+                continue  # the stripped root entry itself
             # Detect LEGITEXT struct files in the tar
             if "/texte/struct/LEGITEXT" in member.name and member.name.endswith(".xml"):
                 # Extract norm_id from path: .../texte/struct/LEGITEXT000006069414.xml
                 norm_id = Path(member.name).stem
                 legitext_ids.add(norm_id)
-        tar.extractall(path=legi_dir, filter="data")
+            members.append(member)
+        tar.extractall(path=legi_dir, members=members, filter="data")
 
     logger.info("Extracted %s: %d LEGITEXT(s) modified", tar_path.name, len(legitext_ids))
     return legitext_ids
+
+
+def _repo_scope(repo_path: str | Path) -> set[str]:
+    """LEGITEXT ids tracked in the country repo — one .md per text, named by id.
+
+    The repo is the scope and it is present in every environment. The filter
+    used to test the client's dump index instead, which is neither: it lists
+    every text in the dump (~114k, not the ~80 codes we track) and it is empty
+    whenever the dump is not on disk — as on a CI runner, where it silently
+    discarded 100% of the daily changes for four and a half months.
+    """
+    return {p.stem for p in Path(repo_path).rglob("LEGITEXT*.md")}
 
 
 def daily(
@@ -123,6 +156,28 @@ def daily(
     legi_path = Path(legi_dir)
     legi_path.mkdir(parents=True, exist_ok=True)
 
+    scope = _repo_scope(cc.repo_path)
+
+    if not dry_run:
+        # Both of these used to degrade into "✓ 0 commits" — a green run that
+        # had silently done nothing. They are fatal: neither is recoverable
+        # from inside the run, and a daily that cannot see its inputs must say
+        # so rather than report success.
+        if not scope:
+            raise RuntimeError(
+                f"No LEGITEXT*.md found under {cc.repo_path} — nothing in scope. "
+                "Wrong --repo-path, or the country was never bootstrapped."
+            )
+        if not (legi_path / "legi" / "global").is_dir():
+            raise RuntimeError(
+                f"LEGI dump not found under {legi_path}/legi/global. Daily increments "
+                "only carry the fragments that changed (on LEGI_20260819, 64% of the "
+                "sections a modified code references were not in the increment), so "
+                "rendering a complete text needs the consolidated dump underneath. "
+                f"Extract Freemium_legi_global_*.tar.gz from {DILA_LEGI_URL} and point "
+                "--legi-dir at it."
+            )
+
     state = StateStore(cc.state_path)
     state.load()
 
@@ -139,7 +194,10 @@ def daily(
         console.print("[green]Nothing to process — up to date[/green]")
         return 0
 
-    console.print(f"[bold]Daily FR — processing {len(dates_to_process)} day(s)[/bold]")
+    console.print(
+        f"[bold]Daily FR — processing {len(dates_to_process)} day(s), "
+        f"{len(scope)} text(s) in scope[/bold]"
+    )
 
     repo = GitRepo(cc.repo_path, config.git.committer_name, config.git.committer_email)
     commits_created = 0
@@ -186,8 +244,8 @@ def daily(
                 errors.append(msg)
                 continue
 
-        # Filter to norms we track (already in client index = in-scope codes)
-        modified_ids = [nid for nid in all_modified if nid in client._text_dir_cache]
+        # Filter to the norms we actually track (the repo's own file list)
+        modified_ids = sorted(all_modified & scope)
 
         if not modified_ids:
             console.print("    No texts modified in scope")

--- a/tests/test_daily_fr.py
+++ b/tests/test_daily_fr.py
@@ -28,6 +28,7 @@ from legalize.fetcher.fr.daily import (
     _extract_increment,
     _find_increment_for_date,
     _list_increments,
+    _repo_scope,
     daily,
 )
 from legalize.fetcher.fr.discovery import LEGIDiscovery
@@ -117,7 +118,11 @@ def _make_increment_tar(tmp_path: Path, date_str: str, norm_ids: dict[str, str])
     tar_path = tmp_path / f"LEGI_{date_str}-180000.tar.gz"
     with tarfile.open(tar_path, "w:gz") as tar:
         for norm_id, xml_content in norm_ids.items():
+            # DILA wraps the whole increment in a YYYYMMDD-HHMMSS/ directory.
+            # The fixture used to omit it, which is why the tests never caught
+            # that increments were landing outside the dump.
             rel_path = (
+                f"{date_str}-180000/"
                 f"legi/global/code_et_TNC_en_vigueur/code_en_vigueur/"
                 f"LEGI/TEXT/00/00/{norm_id}/texte/struct/{norm_id}.xml"
             )
@@ -448,37 +453,41 @@ class TestDiscoverDaily:
 # ─────────────────────────────────────────────
 
 
+def _make_config(tmp_path: Path):
+    """Build a Config with FR pointing to tmp dirs."""
+    from legalize.config import Config, CountryConfig, GitConfig
+
+    legi_dir = tmp_path / "legi"
+    # The consolidated dump root: FR daily refuses to run without it.
+    (legi_dir / "legi" / "global").mkdir(parents=True)
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    # The repo IS the scope. legalize-fr tracks one .md per code, named
+    # after its LEGITEXT id; seed the one the fixtures modify.
+    (repo_path / "fr").mkdir()
+    (repo_path / "fr" / "LEGITEXT000006069414.md").write_text("seed\n")
+    state_path = tmp_path / "state" / "state.json"
+
+    # Init git repo
+    subprocess.run(["git", "init"], cwd=repo_path, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo_path, capture_output=True)
+
+    return Config(
+        git=GitConfig(committer_name="Legalize", committer_email="test@test.com"),
+        countries={
+            "fr": CountryConfig(
+                repo_path=str(repo_path),
+                data_dir=str(tmp_path / "data"),
+                state_path=str(state_path),
+                source={"legi_dir": str(legi_dir)},
+            )
+        },
+    )
+
+
 class TestDailyIntegration:
     """Integration tests for the full daily() pipeline with mocked I/O."""
-
-    def _make_config(self, tmp_path: Path):
-        """Build a Config with FR pointing to tmp dirs."""
-        from legalize.config import Config, CountryConfig, GitConfig
-
-        legi_dir = tmp_path / "legi"
-        legi_dir.mkdir()
-        repo_path = tmp_path / "repo"
-        repo_path.mkdir()
-        state_path = tmp_path / "state" / "state.json"
-
-        # Init git repo
-        subprocess.run(["git", "init"], cwd=repo_path, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_path, capture_output=True)
-        subprocess.run(
-            ["git", "config", "user.email", "t@t.com"], cwd=repo_path, capture_output=True
-        )
-
-        return Config(
-            git=GitConfig(committer_name="Legalize", committer_email="test@test.com"),
-            countries={
-                "fr": CountryConfig(
-                    repo_path=str(repo_path),
-                    data_dir=str(tmp_path / "data"),
-                    state_path=str(state_path),
-                    source={"legi_dir": str(legi_dir)},
-                )
-            },
-        )
 
     def test_no_legi_dir_returns_zero(self, tmp_path):
         """Returns 0 if legi_dir is not configured."""
@@ -494,7 +503,7 @@ class TestDailyIntegration:
     @responses.activate
     def test_dry_run_does_not_create_commits(self, tmp_path):
         """Dry run lists increments but creates no commits."""
-        config = self._make_config(tmp_path)
+        config = _make_config(tmp_path)
         responses.add(responses.GET, DILA_LEGI_URL, body=DILA_DIRECTORY_HTML, status=200)
 
         result = daily(config, target_date=date(2026, 4, 1), dry_run=True)
@@ -509,7 +518,7 @@ class TestDailyIntegration:
     @responses.activate
     def test_no_increment_for_date(self, tmp_path):
         """No increment available for the target date → 0 commits, state advances."""
-        config = self._make_config(tmp_path)
+        config = _make_config(tmp_path)
         # Directory listing with no matching date
         responses.add(
             responses.GET,
@@ -524,7 +533,7 @@ class TestDailyIntegration:
     @responses.activate
     def test_http_error_listing_returns_zero(self, tmp_path):
         """HTTP error listing increments → 0 commits."""
-        config = self._make_config(tmp_path)
+        config = _make_config(tmp_path)
         responses.add(responses.GET, DILA_LEGI_URL, body="Server Error", status=500)
 
         result = daily(config, target_date=date(2026, 4, 1))
@@ -533,7 +542,7 @@ class TestDailyIntegration:
     @responses.activate
     def test_full_pipeline_creates_commit(self, tmp_path):
         """Full happy path: download, extract, discover, process, commit."""
-        config = self._make_config(tmp_path)
+        config = _make_config(tmp_path)
         legi_dir = Path(config.get_country("fr").source["legi_dir"])
         repo_path = Path(config.get_country("fr").repo_path)
 
@@ -631,7 +640,7 @@ class TestDailyIntegration:
     @responses.activate
     def test_no_changes_detected_skips_commit(self, tmp_path):
         """If the same date is processed twice, no duplicate commit."""
-        config = self._make_config(tmp_path)
+        config = _make_config(tmp_path)
         legi_dir = Path(config.get_country("fr").source["legi_dir"])
 
         responses.add(responses.GET, DILA_LEGI_URL, body=DILA_DIRECTORY_HTML, status=200)
@@ -690,11 +699,11 @@ class TestDailyIntegration:
     @responses.activate
     def test_safety_check_skips_short_markdown(self, tmp_path):
         """If new markdown is <50% the size of existing, skip (safety check)."""
-        config = self._make_config(tmp_path)
+        config = _make_config(tmp_path)
         repo_path = Path(config.get_country("fr").repo_path)
 
         # Pre-create a large existing file in the repo
-        (repo_path / "fr").mkdir(parents=True)
+        (repo_path / "fr").mkdir(parents=True, exist_ok=True)
         existing_file = repo_path / "fr" / "LEGITEXT000006069414.md"
         existing_file.write_text("x" * 10000)  # 10KB
         subprocess.run(["git", "add", "."], cwd=repo_path, capture_output=True)
@@ -741,6 +750,189 @@ class TestDailyIntegration:
         # The safety check should prevent the commit because
         # the new markdown (~200 bytes frontmatter) < 50% of 10000 bytes
         assert result == 0
+
+
+# ─────────────────────────────────────────────
+# Tests: the CI scenario — no LEGI dump on disk
+#
+# For four and a half months the FR daily ran green every day and produced
+# nothing: the scope filter was built by scanning the dump, the CI runner has
+# no dump, so the index came out empty and discarded 100% of the modified
+# texts. These tests pin the two halves of that failure.
+# ─────────────────────────────────────────────
+
+
+VERSION_XML_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<TEXTE_VERSION><META><META_COMMUN><ID>{norm_id}</ID><NATURE>CODE</NATURE></META_COMMUN>
+<META_SPEC><META_TEXTE_VERSION><TITRE>{title}</TITRE><TITREFULL>{title}</TITREFULL>
+<ETAT>VIGUEUR</ETAT><DATE_DEBUT>1804-03-21</DATE_DEBUT></META_TEXTE_VERSION>
+<META_TEXTE_CHRONICLE><CID>{norm_id}</CID><DATE_PUBLI>2999-01-01</DATE_PUBLI>
+<DATE_TEXTE>2999-01-01</DATE_TEXTE><DERNIERE_MODIFICATION>2026-04-01</DERNIERE_MODIFICATION>
+<TITRE_TEXTE>{title}</TITRE_TEXTE></META_TEXTE_CHRONICLE></META_SPEC></META>
+<VERSIONS><VERSION etat="VIGUEUR">
+<LIEN_TXT debut="1804-03-21" fin="2999-01-01" id="{norm_id}" num=""/>
+</VERSION></VERSIONS></TEXTE_VERSION>
+"""
+
+
+def _seed_dump_text(legi_dir: Path, norm_id: str, title: str) -> Path:
+    """Put a complete (struct + version) text in the consolidated dump."""
+    struct_file = _make_struct_path(legi_dir, norm_id)
+    struct_file.write_text(STRUCT_XML_CODE.replace("LEGITEXT000006069414", norm_id))
+    version_file = struct_file.parent.parent / "version" / f"{norm_id}.xml"
+    version_file.parent.mkdir(parents=True, exist_ok=True)
+    version_file.write_text(VERSION_XML_TEMPLATE.format(norm_id=norm_id, title=title))
+    return struct_file
+
+
+class TestRepoScope:
+    def test_reads_legitext_files_only(self, tmp_path):
+        (tmp_path / "fr").mkdir()
+        (tmp_path / "fr" / "LEGITEXT000006069414.md").write_text("x")
+        (tmp_path / "fr" / "LEGITEXT000006071194.md").write_text("x")
+        (tmp_path / "README.md").write_text("x")
+
+        assert _repo_scope(tmp_path) == {"LEGITEXT000006069414", "LEGITEXT000006071194"}
+
+    def test_does_not_need_the_dump(self, tmp_path):
+        """The whole point: scope resolution never touches legi_dir."""
+        (tmp_path / "fr").mkdir()
+        (tmp_path / "fr" / "LEGITEXT000006069414.md").write_text("x")
+
+        assert _repo_scope(tmp_path) == {"LEGITEXT000006069414"}
+
+
+class TestIncrementAppliesOverDump:
+    def test_overwrites_the_dump_entry(self, tmp_path):
+        """The increment must patch the dump, not land beside it.
+
+        DILA ships increments inside a YYYYMMDD-HHMMSS/ root. Extracted as-is
+        they ended up in {legi_dir}/20260401-180000/legi/global/..., which the
+        client never reads, so every text re-rendered identical to the commit
+        already in the repo and no reform was ever recorded.
+        """
+        legi_dir = tmp_path / "legi_dump"
+        stale = _make_struct_path(legi_dir, "LEGITEXT000006069414")
+        stale.write_text("<TEXTELR>stale</TEXTELR>")
+
+        tar_path = _make_increment_tar(
+            tmp_path, "20260401", {"LEGITEXT000006069414": STRUCT_XML_CODE}
+        )
+        ids = _extract_increment(tar_path, legi_dir)
+
+        assert ids == {"LEGITEXT000006069414"}
+        assert stale.read_text() == STRUCT_XML_CODE
+        assert not (legi_dir / "20260401-180000").exists()
+        assert list(legi_dir.rglob("LEGITEXT000006069414.xml")) == [stale]
+
+
+class TestFailsLoudlyWithoutInputs:
+    """A daily that cannot see its inputs must fail, not report 0 commits."""
+
+    @responses.activate
+    def test_missing_dump_raises(self, tmp_path):
+        config = _make_config(tmp_path)
+        legi_dir = Path(config.get_country("fr").source["legi_dir"])
+        # Exactly the CI runner: repo checked out, no dump anywhere.
+        (legi_dir / "legi" / "global").rmdir()
+        responses.add(responses.GET, DILA_LEGI_URL, body=DILA_DIRECTORY_HTML, status=200)
+
+        with pytest.raises(RuntimeError, match="LEGI dump not found"):
+            daily(config, target_date=date(2026, 4, 1))
+
+    @responses.activate
+    def test_empty_repo_raises(self, tmp_path):
+        config = _make_config(tmp_path)
+        repo_path = Path(config.get_country("fr").repo_path)
+        (repo_path / "fr" / "LEGITEXT000006069414.md").unlink()
+        responses.add(responses.GET, DILA_LEGI_URL, body=DILA_DIRECTORY_HTML, status=200)
+
+        with pytest.raises(RuntimeError, match="nothing in scope"):
+            daily(config, target_date=date(2026, 4, 1))
+
+    @responses.activate
+    def test_dry_run_still_works_without_dump(self, tmp_path):
+        """Dry run neither downloads nor renders, so it needs neither input."""
+        config = _make_config(tmp_path)
+        (Path(config.get_country("fr").source["legi_dir"]) / "legi" / "global").rmdir()
+        responses.add(responses.GET, DILA_LEGI_URL, body=DILA_DIRECTORY_HTML, status=200)
+
+        assert daily(config, target_date=date(2026, 4, 1), dry_run=True) == 0
+
+
+class TestScopeComesFromRepo:
+    @responses.activate
+    def test_only_tracked_texts_are_committed(self, tmp_path):
+        """The dump holds 114k texts; the repo tracks ~80 codes. Scope = repo.
+
+        The increment modifies two codes, both present in the dump, only one
+        tracked in the repo. The untracked one must not be committed — the old
+        filter tested the dump index, so it would have added it.
+        """
+        config = _make_config(tmp_path)
+        legi_dir = Path(config.get_country("fr").source["legi_dir"])
+        repo_path = Path(config.get_country("fr").repo_path)
+
+        tracked, untracked = "LEGITEXT000006069414", "LEGITEXT000006070721"
+        _seed_dump_text(legi_dir, tracked, "Code civil")
+        _seed_dump_text(legi_dir, untracked, "Code du travail")
+
+        responses.add(responses.GET, DILA_LEGI_URL, body=DILA_DIRECTORY_HTML, status=200)
+        tar_path = _make_increment_tar(
+            tmp_path,
+            "20260401",
+            {tracked: STRUCT_XML_CODE, untracked: STRUCT_XML_CODE},
+        )
+        responses.add(
+            responses.GET,
+            f"{DILA_LEGI_URL}LEGI_20260401-180000.tar.gz",
+            body=tar_path.read_bytes(),
+            status=200,
+        )
+
+        result = daily(config, target_date=date(2026, 4, 1))
+
+        assert result == 1
+        assert {p.name for p in (repo_path / "fr").glob("*.md")} == {f"{tracked}.md"}
+
+    @responses.activate
+    def test_committed_even_when_the_dump_index_is_empty(self, tmp_path, monkeypatch):
+        """Scope must not depend on the client's dump index.
+
+        The index is forced empty here — what a CI runner produced every day
+        ("Built text directory index: 0 entries"). With the old filter this run
+        printed "No texts modified in scope" and committed nothing: the exact
+        four-and-a-half-month silence.
+        """
+        monkeypatch.setattr("legalize.fetcher.fr.client._build_text_dir_index", lambda base: {})
+        config = _make_config(tmp_path)
+        legi_dir = Path(config.get_country("fr").source["legi_dir"])
+        repo_path = Path(config.get_country("fr").repo_path)
+        _seed_dump_text(legi_dir, "LEGITEXT000006069414", "Code civil")
+
+        responses.add(responses.GET, DILA_LEGI_URL, body=DILA_DIRECTORY_HTML, status=200)
+        tar_path = _make_increment_tar(
+            tmp_path, "20260401", {"LEGITEXT000006069414": STRUCT_XML_CODE}
+        )
+        responses.add(
+            responses.GET,
+            f"{DILA_LEGI_URL}LEGI_20260401-180000.tar.gz",
+            body=tar_path.read_bytes(),
+            status=200,
+        )
+
+        result = daily(config, target_date=date(2026, 4, 1))
+
+        assert result == 1
+        log = subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "Code civil" in log.stdout
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## What was wrong

`legalize-fr` has not recorded a single reform since early April, and the daily job
has reported success every day throughout. Three defects, each silent on its own:

**1. The scope filter came from the dump.** `daily.py` filtered the modified
LEGITEXTs against `client._text_dir_cache`, an index built by walking the LEGI dump
on disk. A CI runner has no dump, so the index came out empty
(`Built text directory index: 0 entries`), 100% of the modified texts were
discarded, and the run printed `No texts modified in scope` → `✓ 0 commits`.

It was also the wrong scope in the other direction: that index lists *every* text in
the dump (~114k), not the ~80 codes we track. With a dump present it would have let
untracked JORF texts into the repo. The repo's own file list is the scope — one
`.md` per code, named after its LEGITEXT id — and it exists in every environment.

**2. Increments never reached the dump.** DILA wraps each increment in a
`YYYYMMDD-HHMMSS/` directory; the global dump starts at `legi/`. `tar.extractall()`
put the increment in `{legi_dir}/20260819-222711/legi/global/...`, a tree
`LEGIClient` never reads. It kept parsing pre-increment XML, every text re-rendered
byte-identical to the commit already in the repo, and `write_and_add()` reported no
change. **This one bites with the dump present too** — it means no increment has
ever been applied, locally or in CI.

**3. Missing inputs looked like success.** No dump, or an empty scope, degraded into
`✓ 0 commits`. Both are now hard errors.

## Verified first: what is actually in an increment

`LEGI_20260819-222711.tar.gz` (12 MB, 41k members), against the 83 codes tracked in
`legalize-fr`:

| | |
|---|---|
| LEGITEXT structs modified | 394 (54 codes, 334 TNC) |
| …of which tracked in `legalize-fr` | **55 of 83 codes, in one day** |
| Sections a modified code references, absent from the increment | 141 / 219 (**64%**) |
| Articles reachable through the sections present, absent | 35 / 42 (**83%**) |
| Codes whose tree is complete in the increment | **0** |

**An increment is a delta, not a standalone text.** Rendering a complete text needs
the consolidated dump underneath — the module docstring claimed the opposite
("increments contain the updated consolidated texts directly"), which is where the
design went wrong. Fixed here.

## What this PR does

- Scope from `repo_path` (`_repo_scope()`: `rglob("LEGITEXT*.md")`), not from the dump index.
- `_extract_increment()` strips the tar's `YYYYMMDD-HHMMSS/` root so its files overwrite the dump entries they replace.
- Absent dump or empty scope → `RuntimeError` instead of a green run.
- Module docstring now states the measured reality.

Tests: the fixture built increment tarballs **without** the `YYYYMMDD-HHMMSS/` root,
which is why the suite never caught defect 2 — it now mirrors the real DILA layout.
Five new tests, all of which fail on `main`:

- `TestIncrementAppliesOverDump` — an increment overwrites the stale dump entry and leaves no `20260401-180000/` directory behind.
- `TestFailsLoudlyWithoutInputs` — no dump on disk → raises (the CI scenario); empty repo → raises; `--dry-run` still works without either.
- `TestScopeComesFromRepo` — dump index forced empty (exactly `0 entries`) and the tracked code still gets committed; an increment touching a code the repo does *not* track commits nothing.

Full suite: 1709 passed, 27 skipped.

## What this does NOT fix

FR daily still cannot run on a CI runner, and after this PR it will **say so, in
red, every day** instead of reporting success. That is the intended outcome of the
change, not an oversight: the content has to come from the consolidated dump, and
the runner has none.

Getting it green needs a decision that is outside this PR:

- **Full dump per run** — `Freemium_legi_global_*.tar.gz` is 1.1 GB compressed and took 14 min to pull from DILA at ~1.3 MB/s; uncompressed it does not fit in a GitHub runner's ~14 GB of free disk. Not viable.
- **Pruned dump, cached** — stream the global tar once and keep only the ~80 tracked code subtrees, then restore it from `actions/cache` each day and apply the increment on top. This is the shape I would build. Size measured below.
- **Légifrance PISTE API** — per-text consolidated fetch, no dump at all, but it needs OAuth credentials and a new client.

## The 4.5-month gap

Recoverable, in principle: DILA keeps 397 increments back to 2025-07-12, so the
whole gap is still downloadable. `MAX_LOOKBACK_DAYS = 10` only clamps the cron path
— `backfill.yml` passes `--date` per day and bypasses it. But a backfill needs the
same dump the daily needs, so it is blocked behind the same decision. Replaying
~115 days would also produce a commit per code per day (~55 codes/day on the day I
sampled), which is a separate call to make.

## Verified end to end against real data

Not just fixtures. Pulled the real global dump, kept only the 83 tracked codes,
applied the real `LEGI_20260819` increment on top, and ran the daily against a
throwaway clone of `legalize-fr` (no push):

```
legalize daily -c fr --date 2026-08-19 --legi-dir ./pruned --repo-path ./fr-clone
→ Daily FR — processing 1 day(s), 83 text(s) in scope
→ 54 text(s) modified
→ ✓ 54 commits            (5m47s)
```

On `main` the same command produces `✓ 0 commits`. Among the 54 are genuine
reforms — e.g. Code de la justice pénale des mineurs picking up
`loi n° 2026-651 du 23 juillet 2026` in place of `loi n° 2025-568`.

Caveat on that run, which matters for whoever wires the dump up: the diffs are
much larger than the reform itself (heading levels shift, whole sections
re-flow). DILA's global dump is from **2025-07-13**, so the tree underneath was
13 months stale and only one increment had been applied. A pruned dump has to be
brought current — global, then every increment in order — *before* the first
committing run, or day one writes a spurious full-file rewrite for every code.

## Sizing the pruned dump (measured, not estimated)

| | |
|---|---|
| Global dump | 1.1 GB compressed, 5,253,903 members, 14 min to download at ~1.3 MB/s |
| Streaming pass to keep only the 83 tracked codes | 416 s |
| Result | 705,240 files, **3.3 GB** |

3.3 GB fits a GitHub runner (~14 GB free) and compresses well under the 10 GB
`actions/cache` limit. Seeding is a one-off ~20 min job; a daily run then restores
the cache and applies one 12 MB increment.

Bringing it current from 2025-07-13 means replaying ~400 increments in order
(~5 GB). Do that silently up to the repo's last committed day (early April 2026)
and only then start committing — the replay converges on the state already in the
repo, so the backfill of the 4.5-month gap falls out of the same run.
