### PR TITLE
feat: fail the daily when a country stops producing commits

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,8 @@ countries:
     repo_path: "../countries/ad"
     data_dir: "../countries/data-ad"
     cache_dir: ".cache"
+    # sparse jurisdiction, gaps of months are normal
+    stall_alert_days: 90
     max_workers: 1
     source:
       api_base: "https://bopaazurefunctions.azurewebsites.net/api"
@@ -58,6 +60,8 @@ countries:
   se:
     repo_path: "../countries/se"
     data_dir: "../countries/data-se"
+    # observed max gap 21 d — SFS reform dates are approximate
+    stall_alert_days: 30
     max_workers: 1
     source: {}  # Riksdagen API, no config needed
 
@@ -164,6 +168,8 @@ countries:
     repo_path: "../countries/lu"
     data_dir: "../countries/data-lu"
     cache_dir: ".cache"
+    # observed max gap 90 d
+    stall_alert_days: 120
     # Legilux open data: SPARQL (discovery) + filestore (XML downloads).
     # No documented rate limits. Benchmarked 2026-04-13: server handles
     # 150+ req/s without errors. XML URLs derived deterministically from
@@ -373,6 +379,8 @@ countries:
     repo_path: "../countries/cz"
     data_dir: "../countries/data-cz"
     cache_dir: ".cache"
+    # observed max gap 48 d
+    stall_alert_days: 60
     # Benchmark 2026-04-12 (50 laws, metadata-only):
     #   1w × 5 r/s  →  4.9 laws/s (10s)
     #   4w × 5 r/s  → 18.0 laws/s (2.8s) — sweet spot

--- a/src/legalize/cli.py
+++ b/src/legalize/cli.py
@@ -322,6 +322,41 @@ def bootstrap(
 # ─────────────────────────────────────────────
 
 
+def _report_freshness(config, country: str, *, enforce: bool) -> None:
+    """Report how current a country corpus is, and fail the run if stalled.
+
+    A daily that fetches, finds nothing and exits 0 is indistinguishable
+    from a healthy quiet day — that is how seven countries stayed frozen
+    behind a green CI matrix for two months. Exiting non-zero is the
+    alert: the matrix job turns red, GitHub notifies on failed scheduled
+    runs, and the Actions tab names the country. Nothing to subscribe to
+    and no log to read.
+
+    ``enforce`` is off for --dry-run and for explicit --date runs, so a
+    backfill loop is not aborted by the gap it is there to close.
+    """
+    from legalize.pipeline import days_since_last_norm
+
+    cc = config.get_country(country)
+    stale = days_since_last_norm(config, country)
+
+    if stale is None:
+        reason = "the repo holds no usable pipeline commit at all"
+    elif stale >= cc.stall_alert_days:
+        reason = (
+            f"no norm captured in {stale} days (threshold {cc.stall_alert_days}); "
+            f"the daily ran and produced nothing, so treat this as a broken "
+            f"fetcher until proven otherwise"
+        )
+    else:
+        console.print(f"[dim]Freshness: last norm captured {stale} day(s) ago[/dim]")
+        return
+
+    console.print(f"[bold red]STALLED: {country.upper()} — {reason}.[/bold red]")
+    if enforce:
+        raise SystemExit(1)
+
+
 @cli.command()
 @_country_option()
 @click.option("--date", "target_date", default=None, help="Date to process (YYYY-MM-DD).")
@@ -373,6 +408,8 @@ def daily(
         from legalize.pipeline import generic_daily
 
         generic_daily(config, country, target_date=parsed_date, dry_run=dry_run)
+
+    _report_freshness(config, country, enforce=not dry_run and parsed_date is None)
 
 
 # ─────────────────────────────────────────────
@@ -718,6 +755,7 @@ def status(ctx: click.Context) -> None:
     """Show pipeline status."""
     from pathlib import Path
 
+    from legalize.pipeline import days_since_last_norm
     from legalize.state.store import StateStore
 
     config = ctx.obj["config"]
@@ -739,6 +777,15 @@ def status(ctx: click.Context) -> None:
             state = StateStore(cc.state_path)
             state.load()
 
+            stale = days_since_last_norm(config, code)
+            if stale is None:
+                freshness = "[red]no pipeline commits[/red]"
+            elif stale >= cc.stall_alert_days:
+                freshness = f"[red]{stale} day(s) ago — STALLED[/red]"
+            else:
+                freshness = f"{stale} day(s) ago"
+
             console.print(f"\n  [bold]{code.upper()}[/bold]")
             console.print(f"    Downloaded norms: {count}")
             console.print(f"    Last summary: {state.last_summary_date or '[dim]none[/dim]'}")
+            console.print(f"    Last norm captured: {freshness}")

--- a/src/legalize/config.py
+++ b/src/legalize/config.py
@@ -31,6 +31,11 @@ class CountryConfig:
     cache_dir: str = ".cache"
     max_workers: int = 1
     state_path: str = ""  # default: .pipeline/{code}/state.json
+    # Days without a newly captured norm before the daily reports the
+    # country as stalled. Tune per country from its observed cadence:
+    # a source that legitimately goes quiet for weeks needs a longer
+    # window, or the alert trains everyone to ignore it.
+    stall_alert_days: int = 14
     source: dict[str, Any] = field(default_factory=dict)
 
 
@@ -81,6 +86,7 @@ def load_config(path: str | Path = "config.yaml", overrides: dict | None = None)
             cache_dir=country_raw.get("cache_dir", ".cache"),
             max_workers=country_raw.get("max_workers", 1),
             state_path=country_raw.get("state_path", ""),
+            stall_alert_days=country_raw.get("stall_alert_days", CountryConfig.stall_alert_days),
             source=country_raw.get("source", {}),
         )
 

--- a/src/legalize/pipeline.py
+++ b/src/legalize/pipeline.py
@@ -33,7 +33,7 @@ from legalize.models import (
     ParsedNorm,
     Reform,
 )
-from legalize.state.store import StateStore, resolve_dates_to_process
+from legalize.state.store import StateStore, latest_source_date, resolve_dates_to_process
 from legalize.storage import load_norma_from_json, save_structured_json
 from legalize.transformer.markdown import render_norm_at_date
 from legalize.transformer.slug import norm_to_filepath
@@ -97,6 +97,20 @@ def finalize_daily(
         console.print(f"[yellow]⚠ {len(errors)} errors[/yellow]")
 
     return commits_created
+
+
+def days_since_last_norm(config: Config, country: str) -> int | None:
+    """Days since the most recent norm the pipeline captured for a country.
+
+    Reads the newest non-future ``Source-Date`` in the country repo, which
+    is the only usable freshness signal there: commit timestamps carry the
+    norm's own date, not when the pipeline ran.
+
+    Returns None when the repo holds no usable pipeline commit at all.
+    """
+    cc = config.get_country(country)
+    latest = latest_source_date(cc.repo_path)
+    return None if latest is None else (date.today() - latest).days
 
 
 def generic_daily(

--- a/tests/test_daily_freshness.py
+++ b/tests/test_daily_freshness.py
@@ -1,0 +1,138 @@
+"""Tests for the stall alert: a daily that produces nothing must go red.
+
+Seven country dailies exited 0 every morning for two months while their
+repos stood still. A quiet source and a broken fetcher produced byte-for-byte
+identical output, so nothing ever surfaced. These tests pin the signal that
+tells them apart.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import date, timedelta
+
+import pytest
+
+from legalize.cli import _report_freshness
+from legalize.config import CountryConfig, load_config
+from legalize.config import Config as PipelineConfig
+from legalize.pipeline import days_since_last_norm
+
+TODAY = date.today()
+
+
+def _repo_with(tmp_path, *source_dates, trailerless_tip: bool = False):
+    """Build a country repo whose pipeline commits carry the given trailers."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Legalize"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "b@t.dev"], cwd=repo, capture_output=True)
+
+    for source_date in source_dates:
+        (repo / "law.md").write_text(str(source_date))
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+        # The committer stamps the norm's own date, not wall-clock time.
+        stamp = f"{source_date} 00:00:00 +0000"
+        subprocess.run(
+            ["git", "commit", "-m", f"[reform] x\n\nSource-Date: {source_date}"],
+            cwd=repo,
+            capture_output=True,
+            check=True,
+            env={**os.environ, "GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp},
+        )
+
+    if trailerless_tip:
+        (repo / "LICENSE").write_text("MIT")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add LICENSE: MIT pipeline code"],
+            cwd=repo,
+            capture_output=True,
+            check=True,
+        )
+    return repo
+
+
+def _config(repo, *, stall_alert_days: int = 14) -> PipelineConfig:
+    return PipelineConfig(
+        countries={"xx": CountryConfig(repo_path=str(repo), stall_alert_days=stall_alert_days)}
+    )
+
+
+class TestDaysSinceLastNorm:
+    def test_counts_from_the_newest_captured_norm(self, tmp_path):
+        repo = _repo_with(tmp_path, TODAY - timedelta(days=40), TODAY - timedelta(days=3))
+
+        assert days_since_last_norm(_config(repo), "xx") == 3
+
+    def test_a_docs_sweep_cannot_make_a_stale_repo_look_fresh(self, tmp_path):
+        """The 2026-06-23 LICENSE sweep touched all 23 repos and hid this."""
+        repo = _repo_with(tmp_path, TODAY - timedelta(days=60), trailerless_tip=True)
+
+        assert days_since_last_norm(_config(repo), "xx") == 60
+
+    def test_future_dated_trailers_are_not_counted_as_fresh(self, tmp_path):
+        """A bootstrap-only repo is stale, however far in the future its tip is."""
+        repo = _repo_with(tmp_path, TODAY - timedelta(days=90), date(2034, 1, 1))
+
+        assert days_since_last_norm(_config(repo), "xx") == 90
+
+    def test_none_when_the_repo_has_no_pipeline_commits(self, tmp_path):
+        repo = _repo_with(tmp_path, trailerless_tip=True)
+
+        assert days_since_last_norm(_config(repo), "xx") is None
+
+
+class TestReportFreshness:
+    def test_fails_the_run_once_past_the_threshold(self, tmp_path):
+        config = _config(_repo_with(tmp_path, TODAY - timedelta(days=20)), stall_alert_days=14)
+
+        with pytest.raises(SystemExit) as exc:
+            _report_freshness(config, "xx", enforce=True)
+        assert exc.value.code == 1
+
+    def test_fails_when_there_is_nothing_to_measure(self, tmp_path):
+        config = _config(_repo_with(tmp_path, trailerless_tip=True))
+
+        with pytest.raises(SystemExit):
+            _report_freshness(config, "xx", enforce=True)
+
+    def test_quiet_but_within_threshold_passes(self, tmp_path):
+        config = _config(_repo_with(tmp_path, TODAY - timedelta(days=13)), stall_alert_days=14)
+
+        _report_freshness(config, "xx", enforce=True)
+
+    def test_a_longer_per_country_threshold_is_honoured(self, tmp_path):
+        """Sparse jurisdictions (ad, lu) must not cry wolf every fortnight."""
+        config = _config(_repo_with(tmp_path, TODAY - timedelta(days=45)), stall_alert_days=90)
+
+        _report_freshness(config, "xx", enforce=True)
+
+    def test_reports_without_failing_when_not_enforcing(self, tmp_path):
+        """--dry-run and --date backfills must not abort on the gap they close."""
+        config = _config(_repo_with(tmp_path, TODAY - timedelta(days=200)))
+
+        _report_freshness(config, "xx", enforce=False)
+
+
+class TestStallAlertDaysConfig:
+    def test_defaults_to_two_weeks(self):
+        assert CountryConfig().stall_alert_days == 14
+
+    def test_is_read_from_config_yaml(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "countries:\n"
+            "  xx:\n"
+            '    repo_path: "/tmp/xx"\n'
+            "    stall_alert_days: 90\n"
+            "  yy:\n"
+            '    repo_path: "/tmp/yy"\n'
+        )
+
+        config = load_config(str(cfg))
+
+        assert config.get_country("xx").stall_alert_days == 90
+        assert config.get_country("yy").stall_alert_days == 14


### PR DESCRIPTION
> **Stacked on #78** — base is `fix/daily-future-date-guard`, because the alert reuses `latest_source_date()` from that PR. Merge #78 first and this retargets to `main` on its own.

## Why

A daily that fetches, finds nothing and exits 0 is **byte-for-byte indistinguishable** from a healthy quiet day.

That is how seven countries (pl, lt, be, ee, fi, gr, it) sat frozen behind a green CI matrix for two months, and how fr and pt went 4.5 and 3 months without capturing a single norm while their jobs reported success every single morning. Every signal that existed pointed at "fine".

## What it does

The check runs at the end of `legalize daily` and **exits 1** when the country repo has captured no new norm for `stall_alert_days`.

In CI that turns the matrix job red — which *is* the alert. GitHub notifies on failed scheduled runs and the Actions tab names the country. No new service, no webhook, no secret, nothing to subscribe to, and nothing sitting in a log waiting to be read. `fail-fast: false` is already set on the matrix, so one stalled country does not mask the others.

```
STALLED: NL — no norm captured in 79 days (threshold 14); the daily ran and
produced nothing, so treat this as a broken fetcher until proven otherwise.
```

`legalize status` prints the same figure per country, so the state of the whole fleet is one local command away.

## The signal

The newest **non-future `Source-Date`** in the repo, via `latest_source_date()`.

Two things it deliberately does not use:

- **Git timestamps.** `GitRepo.commit` sets `GIT_COMMITTER_DATE` to the norm's own date, so a repo whose tip commit is stamped 2034 is stale, not fresh. Every date in a country repo is semantic, never wall-clock.
- **Trailer-less commits.** A docs sweep across every country repo — as on 2026-06-23 — cannot make a stale repo look updated. That sweep is exactly what masked this for two months.

## Thresholds

`stall_alert_days` defaults to **14** and is per-country, because a threshold that cries wolf gets ignored within a week.

The four overrides come from each repo's own measured `Source-Date` cadence — max gap over its last 100 pipeline commits, sampled 2026-08-20:

| País | Umbral | Motivo |
|---|---|---|
| se | 30 | max gap observado 21 d; las fechas SFS son aproximadas |
| cz | 60 | max gap observado 48 d |
| lu | 120 | max gap observado 90 d |
| ad | 90 | jurisdicción pequeña, huecos de meses son normales |

Expect to tune these after a week of real runs — the sample window is short for the sparser countries.

## What merging this will do immediately

**It will turn the daily red for every country that is actually broken**, which right now is fr, pt and the seven frozen ones until #78 lands and they are backfilled. That is the intended behaviour, not a regression: those jobs have been lying for months. Worth merging with eyes open, and possibly right after the backfill rather than before it.

Enforcement is off for `--dry-run` and for explicit `--date` runs, so a backfill loop is not aborted by the very gap it is closing.

## Tests

New `tests/test_daily_freshness.py` — 11 tests covering: the age calculation, a trailer-less docs sweep on top of a stale repo, future-dated trailers not counting as fresh, a repo with no pipeline commits at all, threshold enforcement above and below the line, per-country overrides, `enforce=False`, and the config default plus YAML override.

Verified against real clones: `es → 3 days` (passes), `nl → 79 days` on a deliberately stale local clone (exits 1).

Full suite: 1723 passed, 27 skipped. `ruff check` + `ruff format --check` clean.

Co-Authored-By: Claude <noreply@anthropic.com>