### PR TITLE
chore(ci): pin ruff so lint rules stop changing without a commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,13 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      # Pinned on purpose: the job installed whatever ruff was newest, so the
+      # lint rules changed under the repo without a commit. 0.16 widened the
+      # default rule set and CI went from clean to 476 errors overnight on
+      # code nobody had touched, while pre-commit (language: system) kept
+      # using the locally installed ruff and stayed green. Bump deliberately,
+      # together with the fixes the new rules ask for.
+      - run: pip install ruff==0.15.8
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
 


### PR DESCRIPTION
## What happened

The lint job ran `pip install ruff`, so it silently tracked the newest release.

**ruff 0.16.3** widened the default rule set, and CI went from clean to **476 errors** overnight — `BLE001` (74), `PLW1510` (61), `DTZ011` (46), `I001` (45), `G201` (34)… — on code nobody had touched. The last CI run on `main` was 2026-07-08 and passed; every PR opened since ruff 0.16 shipped is red on lint regardless of its contents.

pre-commit did not catch it because its hooks use `language: system`, so locally everyone kept running the ruff they already had installed (0.15.8 here).

## The fix

Pin to `ruff==0.15.8`, the version the repo is actually clean under. Bumping becomes a deliberate commit that lands together with the fixes the new rules ask for.

`[tool.ruff]` in `pyproject.toml` sets only `target-version` and `line-length` — no `select` — so the project inherits ruff's defaults wholesale. Worth choosing an explicit rule set at some point; that is a bigger call than this PR.

## Why it is separate

Found while opening #78 and #81 — both are red on lint for this reason, not for anything in their diffs. Kept out of those PRs so the CI change is visible on its own rather than smuggled into a fix.

Co-Authored-By: Claude <noreply@anthropic.com>