### PR TITLE
fix(fi): send publishedSince as a timezone-qualified instant

### DIFF
--- a/src/legalize/fetcher/fi/discovery.py
+++ b/src/legalize/fetcher/fi/discovery.py
@@ -70,13 +70,17 @@ class FinlexDiscovery(NormDiscovery):
     ) -> Iterator[str]:
         """Yield IDs of statutes modified since *target_date*.
 
-        Uses the ``publishedSince`` query parameter which accepts an
-        ISO datetime string.  We query for anything published since
-        midnight of the target date.
+        Uses the ``publishedSince`` query parameter, which takes an ISO
+        8601 *instant* — the offset is required. We query for anything
+        published since midnight UTC of the target date.
+
+        Finlex used to accept a naive ``YYYY-MM-DDTHH:MM:SS`` and now
+        answers 400 to it, which turned every day of the daily into an
+        error and Finland into a repo that had not moved since August.
         """
         assert isinstance(client, FinlexClient)
 
-        since = f"{target_date.isoformat()}T00:00:00"
+        since = f"{target_date.isoformat()}T00:00:00Z"
         page = 1
         total = 0
         seen: set[str] = set()

--- a/tests/test_discovery_fi.py
+++ b/tests/test_discovery_fi.py
@@ -1,0 +1,77 @@
+"""Tests for the Finnish Finlex daily discovery.
+
+Finlex answers 400 to a naive ``publishedSince``. The daily sent one for
+months, so every day of every run raised and Finland captured nothing while
+the job still reported success.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from legalize.fetcher.fi.client import FinlexClient
+from legalize.fetcher.fi.discovery import FinlexDiscovery
+
+_URI = "https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute-consolidated"
+
+
+class _RecordingClient(FinlexClient):
+    """Captures the query the discovery builds; serves one page of results."""
+
+    def __init__(self, pages: list[list[dict]] | None = None) -> None:
+        super().__init__()
+        self.asked: list[str | None] = []
+        self._pages = pages if pages is not None else [[{"akn_uri": f"{_URI}/2019/469/fin@"}]]
+
+    def list_statutes(self, page: int = 1, limit: int = 10, **kwargs) -> list[dict]:
+        self.asked.append(kwargs.get("published_since"))
+        return self._pages[page - 1] if page <= len(self._pages) else []
+
+
+class TestPublishedSinceFormat:
+    def test_is_a_timezone_qualified_instant(self):
+        """The offset is what the API validates; a naive value is a 400."""
+        client = _RecordingClient()
+
+        list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10)))
+
+        assert client.asked, "discovery never queried the API"
+        for asked in client.asked:
+            parsed = datetime.fromisoformat(asked)
+            assert parsed.tzinfo is not None, f"{asked!r} has no offset — Finlex answers 400"
+            assert parsed.utcoffset().total_seconds() == 0
+            assert parsed.date() == date(2026, 8, 10)
+            assert (parsed.hour, parsed.minute, parsed.second) == (0, 0, 0)
+
+    def test_every_page_uses_the_same_instant(self):
+        """Paging must not drift the cursor mid-walk."""
+        page = [{"akn_uri": f"{_URI}/2019/{n}/fin@"} for n in range(10)]
+        client = _RecordingClient(pages=[page, page[:2]])
+
+        list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10)))
+
+        assert len(client.asked) == 2
+        assert len(set(client.asked)) == 1
+
+
+class TestDiscoverDaily:
+    def test_yields_deduplicated_norm_ids(self):
+        """The same statute appears once per language expression."""
+        client = _RecordingClient(
+            pages=[
+                [
+                    {"akn_uri": f"{_URI}/2019/469/fin@"},
+                    {"akn_uri": f"{_URI}/2019/469/swe@"},
+                    {"akn_uri": f"{_URI}/1989/415/fin@20221099"},
+                ]
+            ]
+        )
+
+        got = list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10)))
+
+        assert got == ["2019/469", "1989/415"]
+
+    def test_empty_page_ends_the_walk(self):
+        client = _RecordingClient(pages=[[]])
+
+        assert list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10))) == []


### PR DESCRIPTION
## Diagnóstico

El daily de Finlandia daba **9 errores y 0 commits** cada día. La causa es una sola línea, `fetcher/fi/discovery.py:79`:

```py
since = f"{target_date.isoformat()}T00:00:00"   # naive → 400
```

Finlex valida `publishedSince` como un **instante ISO 8601** y exige el offset. Sin él responde 400:

```
HTTPError: 400 Client Error: Bad Request for url:
.../statute-consolidated/list?format=json&page=1&limit=10
&langAndVersion=fin%40&publishedSince=2026-08-10T00%3A00%3A00
```

`generic_daily` captura los errores de discovery por día y sigue, así que el run terminaba en **exit 0** — `⚠ 9 errors`, `✓ 0 commits` — y Finlandia llevaba sin capturar nada desde 2026-08-01 con el CI en verde.

## Verificación contra la API real

Aislé el parámetro culpable probando combinaciones contra `opendata.finlex.fi`:

| Petición | Resultado |
|---|---|
| exacta del fetcher (`publishedSince` naive) | **400** |
| sin `langAndVersion` | 400 |
| sin `publishedSince` | 200 |
| `publishedSince=2026-08-10` (solo fecha) | 400 |
| `publishedSince=2026-08-10T00:00:00Z` | **200** |

Y comprobé que con `Z` el parámetro **filtra de verdad**, no lo ignora: `publishedSince=2026-08-10Z` devuelve resultados distintos de la consulta sin filtro, mientras que un parámetro inventado (`publishedAfter=…`) devuelve exactamente lo mismo que sin filtro. Un 200 no bastaba como prueba: la API se traga en silencio los parámetros que no conoce.

Con el `discover_daily` real del repo y el fix puesto:

```
2026-08-10 -> 857 normas
2026-08-15 -> 791 normas
2026-08-19 -> 0 normas
```

Ahora mismo son 0 en los tres casos, porque revienta antes.

## Tests

Nuevo `tests/test_discovery_fi.py` (4 tests, **1 falla contra el código actual**). El test no fija el literal `"Z"`, fija el contrato que la API valida: parsea lo que la discovery construye con `datetime.fromisoformat` y exige `tzinfo is not None`. Así sigue valiendo si algún día pasamos a `+00:00`.

Cubre también que el instante no derive entre páginas al paginar, la deduplicación por expresión de idioma (`fin@`/`swe@` de la misma norma), y el fin de recorrido con página vacía.

Suite completa: 1747 passed, 27 skipped. `ruff check` + `ruff format --check` limpios.

## Alcance

Solo Finlandia. El hueco acumulado (desde 2026-08-01) no lo cierra esto: `MAX_LOOKBACK_DAYS = 10` sigue mandando y hace falta un backfill con `--date`. Es decisión aparte y no la tomo aquí.

Co-Authored-By: Claude <noreply@anthropic.com>