### PR TITLE
fix(fi): bound each daily day to its own changes

### DIFF
--- a/src/legalize/fetcher/fi/discovery.py
+++ b/src/legalize/fetcher/fi/discovery.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterator
-from datetime import date
+from datetime import date, timedelta
 
 from legalize.fetcher.base import LegislativeClient, NormDiscovery
 from legalize.fetcher.fi.client import FinlexClient
@@ -33,8 +33,15 @@ class FinlexDiscovery(NormDiscovery):
     """Discovers Finnish consolidated statutes via the Finlex API.
 
     Bootstrap: ~4,250 paginated requests (10 items/page × ~42,500 statutes).
-    Daily: 1-2 paginated requests using publishedSince filter.
+    Daily: one pagination per date in the window (see discover_daily).
     """
+
+    def __init__(self) -> None:
+        # "Everything modified on or after D", per date. generic_daily walks
+        # the window forward and each date is needed twice — once as the day
+        # itself, once as the previous day's upper bound — so caching turns
+        # two paginations per day into one.
+        self._since_cache: dict[date, list[str]] = {}
 
     def discover_all(self, client: LegislativeClient, **kwargs) -> Iterator[str]:
         """Yield all consolidated statute IDs as ``{year}/{number}``."""
@@ -65,32 +72,19 @@ class FinlexDiscovery(NormDiscovery):
 
         logger.info("Discovery complete: %d unique statutes across %d pages", total, page)
 
-    def discover_daily(
-        self, client: LegislativeClient, target_date: date, **kwargs
-    ) -> Iterator[str]:
-        """Yield IDs of statutes modified since *target_date*.
+    def _ids_since(self, client: FinlexClient, since: date) -> list[str]:
+        """Every statute Finlex reports as modified on or after *since*."""
+        cached = self._since_cache.get(since)
+        if cached is not None:
+            return cached
 
-        Uses the ``publishedSince`` query parameter, which takes an ISO
-        8601 *instant* — the offset is required. We query for anything
-        published since midnight UTC of the target date.
-
-        Finlex used to accept a naive ``YYYY-MM-DDTHH:MM:SS`` and now
-        answers 400 to it, which turned every day of the daily into an
-        error and Finland into a repo that had not moved since August.
-        """
-        assert isinstance(client, FinlexClient)
-
-        since = f"{target_date.isoformat()}T00:00:00Z"
+        stamp = f"{since.isoformat()}T00:00:00Z"
         page = 1
-        total = 0
+        ids: list[str] = []
         seen: set[str] = set()
 
         while True:
-            items = client.list_statutes(
-                page=page,
-                limit=_PAGE_SIZE,
-                published_since=since,
-            )
+            items = client.list_statutes(page=page, limit=_PAGE_SIZE, published_since=stamp)
             if not items:
                 break
 
@@ -98,12 +92,50 @@ class FinlexDiscovery(NormDiscovery):
                 norm_id = _extract_norm_id(item.get("akn_uri", ""))
                 if norm_id and norm_id not in seen:
                     seen.add(norm_id)
-                    total += 1
-                    yield norm_id
+                    ids.append(norm_id)
 
             if len(items) < _PAGE_SIZE:
                 break
             page += 1
+
+        # Only this date and the ones after it can still be asked for.
+        self._since_cache = {d: v for d, v in self._since_cache.items() if d >= since}
+        self._since_cache[since] = ids
+        return ids
+
+    def discover_daily(
+        self, client: LegislativeClient, target_date: date, **kwargs
+    ) -> Iterator[str]:
+        """Yield statutes whose most recent modification falls on *target_date*.
+
+        ``publishedSince`` is a cumulative lower bound — everything modified
+        from that instant onwards, not what changed that day. Finlex offers no
+        upper bound: publishedBefore, publishedUntil, publishedTo, dateTo and
+        every other candidate are accepted and then silently ignored, and the
+        list items carry nothing but an AKN URI and a status, so there is no
+        date to bound on client-side either. The day's set is therefore the
+        difference between two cumulative queries.
+
+        Without that difference a 9-day window asked for "everything since day
+        one" nine times over — 6,394 statute fetches for 857 distinct statutes
+        — and ran the job past its 55-minute cap. Worse than slow: each day
+        re-rendered the same statute with that day's date in ``last_updated``
+        (transformer.frontmatter), so one statute would have been committed
+        once per day of the window, each time under a different date.
+
+        A statute modified twice inside the window is yielded once, on the day
+        of its latest modification.
+        """
+        assert isinstance(client, FinlexClient)
+
+        on_or_after = self._ids_since(client, target_date)
+        later = set(self._ids_since(client, target_date + timedelta(days=1)))
+
+        total = 0
+        for norm_id in on_or_after:
+            if norm_id not in later:
+                total += 1
+                yield norm_id
 
         logger.info("Daily discovery for %s: %d statutes", target_date, total)
 

--- a/tests/test_discovery_fi.py
+++ b/tests/test_discovery_fi.py
@@ -1,37 +1,58 @@
 """Tests for the Finnish Finlex daily discovery.
 
-Finlex answers 400 to a naive ``publishedSince``. The daily sent one for
-months, so every day of every run raised and Finland captured nothing while
-the job still reported success.
+Two bugs lived here. Finlex answers 400 to a naive ``publishedSince``, so
+every day of every run raised while the job still reported success. And
+``publishedSince`` is a *cumulative* lower bound with no upper bound
+available, so once the 400 was fixed each day of the window asked for
+everything from that day to today — the same statutes over and over.
 """
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from legalize.fetcher.fi.client import FinlexClient
 from legalize.fetcher.fi.discovery import FinlexDiscovery
 
 _URI = "https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute-consolidated"
+_PAGE = 10
 
 
-class _RecordingClient(FinlexClient):
-    """Captures the query the discovery builds; serves one page of results."""
+class _FakeFinlex(FinlexClient):
+    """Serves the real API's semantics: publishedSince is cumulative.
 
-    def __init__(self, pages: list[list[dict]] | None = None) -> None:
+    Built from ``{day: [norm_ids modified that day]}``; a query for day D
+    returns everything modified on D or later, paginated 10 at a time.
+    """
+
+    def __init__(self, by_day: dict[date, list[str]]) -> None:
         super().__init__()
-        self.asked: list[str | None] = []
-        self._pages = pages if pages is not None else [[{"akn_uri": f"{_URI}/2019/469/fin@"}]]
+        self._by_day = by_day
+        self.asked: list[str] = []
 
-    def list_statutes(self, page: int = 1, limit: int = 10, **kwargs) -> list[dict]:
-        self.asked.append(kwargs.get("published_since"))
-        return self._pages[page - 1] if page <= len(self._pages) else []
+    def list_statutes(self, page: int = 1, limit: int = _PAGE, **kwargs) -> list[dict]:
+        stamp = kwargs.get("published_since")
+        self.asked.append(stamp)
+        since = datetime.fromisoformat(stamp).date()
+
+        ids: list[str] = []
+        for day in sorted(self._by_day):
+            if day >= since:
+                ids += self._by_day[day]
+
+        window = ids[(page - 1) * _PAGE : page * _PAGE]
+        return [{"akn_uri": f"{_URI}/{n}/fin@", "status": "MODIFIED"} for n in window]
+
+
+def _ids(n: int, year: str) -> list[str]:
+    """Norm ids in Finlex's ``{year}/{number}`` shape."""
+    return [f"{year}/{i}" for i in range(1, n + 1)]
 
 
 class TestPublishedSinceFormat:
     def test_is_a_timezone_qualified_instant(self):
         """The offset is what the API validates; a naive value is a 400."""
-        client = _RecordingClient()
+        client = _FakeFinlex({date(2026, 8, 10): ["2019/469"]})
 
         list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10)))
 
@@ -40,38 +61,88 @@ class TestPublishedSinceFormat:
             parsed = datetime.fromisoformat(asked)
             assert parsed.tzinfo is not None, f"{asked!r} has no offset — Finlex answers 400"
             assert parsed.utcoffset().total_seconds() == 0
-            assert parsed.date() == date(2026, 8, 10)
             assert (parsed.hour, parsed.minute, parsed.second) == (0, 0, 0)
 
-    def test_every_page_uses_the_same_instant(self):
-        """Paging must not drift the cursor mid-walk."""
-        page = [{"akn_uri": f"{_URI}/2019/{n}/fin@"} for n in range(10)]
-        client = _RecordingClient(pages=[page, page[:2]])
 
-        list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10)))
-
-        assert len(client.asked) == 2
-        assert len(set(client.asked)) == 1
-
-
-class TestDiscoverDaily:
-    def test_yields_deduplicated_norm_ids(self):
-        """The same statute appears once per language expression."""
-        client = _RecordingClient(
-            pages=[
-                [
-                    {"akn_uri": f"{_URI}/2019/469/fin@"},
-                    {"akn_uri": f"{_URI}/2019/469/swe@"},
-                    {"akn_uri": f"{_URI}/1989/415/fin@20221099"},
-                ]
-            ]
+class TestBoundedToASingleDay:
+    def test_yields_only_what_changed_that_day(self):
+        """The real shape: 66 statutes on the 10th, 791 on the 17th."""
+        client = _FakeFinlex(
+            {date(2026, 8, 10): _ids(66, "2019"), date(2026, 8, 17): _ids(791, "2024")}
         )
+        discovery = FinlexDiscovery()
 
-        got = list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10)))
+        tenth = list(discovery.discover_daily(client, date(2026, 8, 10)))
+        seventeenth = list(discovery.discover_daily(client, date(2026, 8, 17)))
 
-        assert got == ["2019/469", "1989/415"]
+        assert len(tenth) == 66
+        assert len(seventeenth) == 791
+        assert set(tenth).isdisjoint(seventeenth)
 
-    def test_empty_page_ends_the_walk(self):
-        client = _RecordingClient(pages=[[]])
+    def test_a_quiet_day_inside_the_window_yields_nothing(self):
+        """Cumulatively there are 791 pending; on this day, none of them."""
+        client = _FakeFinlex({date(2026, 8, 17): _ids(791, "2024")})
 
-        assert list(FinlexDiscovery().discover_daily(client, date(2026, 8, 10))) == []
+        got = list(FinlexDiscovery().discover_daily(client, date(2026, 8, 12)))
+
+        assert got == []
+
+    def test_the_last_day_of_the_window_yields_its_own_changes(self):
+        """Nothing after it, so the upper-bound query comes back empty."""
+        client = _FakeFinlex({date(2026, 8, 20): ["2026/1", "2026/2"]})
+
+        got = list(FinlexDiscovery().discover_daily(client, date(2026, 8, 20)))
+
+        assert got == ["2026/1", "2026/2"]
+
+    def test_a_statute_touched_twice_lands_on_its_latest_day(self):
+        """No statute may be committed twice under two different dates."""
+        client = _FakeFinlex({date(2026, 8, 10): ["1999/731"], date(2026, 8, 12): ["1999/731"]})
+        discovery = FinlexDiscovery()
+
+        days = [
+            list(discovery.discover_daily(client, date(2026, 8, 10) + timedelta(days=i)))
+            for i in range(3)
+        ]
+
+        assert days == [[], [], ["1999/731"]]
+
+    def test_whole_window_yields_each_statute_exactly_once(self):
+        by_day = {
+            date(2026, 8, 10): _ids(66, "2019"),
+            date(2026, 8, 17): _ids(791, "2024"),
+        }
+        discovery = FinlexDiscovery()
+        client = _FakeFinlex(by_day)
+
+        seen: list[str] = []
+        for i in range(11):
+            seen += discovery.discover_daily(client, date(2026, 8, 10) + timedelta(days=i))
+
+        assert len(seen) == len(set(seen)) == 857
+
+
+class TestPaginationCost:
+    def test_consecutive_days_reuse_the_previous_upper_bound(self):
+        """One new pagination per day, not two — the walk is forward-only."""
+        client = _FakeFinlex({date(2026, 8, 17): _ids(20, "2024")})
+        discovery = FinlexDiscovery()
+
+        for i in range(3):
+            list(discovery.discover_daily(client, date(2026, 8, 10) + timedelta(days=i)))
+
+        assert sorted(set(client.asked)) == [
+            "2026-08-10T00:00:00Z",
+            "2026-08-11T00:00:00Z",
+            "2026-08-12T00:00:00Z",
+            "2026-08-13T00:00:00Z",
+        ]
+
+    def test_the_cache_does_not_grow_with_the_window(self):
+        client = _FakeFinlex({date(2026, 8, 17): _ids(5, "2024")})
+        discovery = FinlexDiscovery()
+
+        for i in range(11):
+            list(discovery.discover_daily(client, date(2026, 8, 10) + timedelta(days=i)))
+
+        assert len(discovery._since_cache) <= 2


### PR DESCRIPTION
## Qué significa realmente `publishedSince`

Confirmado: **es un límite inferior acumulativo**. Devuelve todo lo modificado desde ese instante en adelante, no lo que cambió ese día.

Medido contra la API real el 2026-08-20, día a día, contando por búsqueda binaria sobre la paginación:

| publishedSince | resultados |     | publishedSince | resultados |
|---|---|---|---|---|
| 08-10 | **857** | | 08-16 | 791 |
| 08-11 | 791 | | 08-17 | 791 |
| 08-12 | 791 | | 08-18 | **0** |
| 08-13 | 791 | | 08-19 | 0 |
| 08-14 | 791 | | 08-20 | 0 |
| 08-15 | 791 | | | |

Monótona no creciente en los once puntos: la firma de un filtro acumulativo. Si seleccionara "lo publicado ese día" no habría ninguna relación de orden entre las cifras.

## Cuántas normas hay de verdad al día

Las diferencias entre días consecutivos dan el volumen real:

- **66** el 2026-08-10
- **791** el 2026-08-17 (una tanda de consolidación en bloque)
- **0** los otros nueve días

Total distinto en la ventana: **857**, que es exactamente lo que da `since=08-10`, como debe ser.

Así que sí, tu sospecha era correcta en la forma pero no en la magnitud: no son "unidades o decenas todos los días", son ceros casi todos los días y un pico de 791 en uno solo. Finlandia consolida por lotes.

## Por qué se comía los 55 minutos

Con la ventana de 9 días, el daily pedía "todo desde el día uno" nueve veces:

```
857 + 791×7 + 0×2 = 6.394 procesados  →  857 distintos
```

`generic_daily` no deduplica entre días: por cada id llama a `get_metadata` y `get_text`, dos peticiones. A `requests_per_second: 2.0` son ~12.800 peticiones ≈ 1h 50m. El tope del job es 55 min.

## Y no era solo lento: era incorrecto

`generic_daily` renderiza cada norma con el día que está procesando, y `transformer/frontmatter.py:48` lo escribe en `last_updated`. La misma norma sale con markdown distinto cada día → `write_and_add` detecta cambio → **commit nuevo cada día de la ventana, cada uno con una fecha distinta**.

Las 791 normas del 17-ago habrían entrado hasta siete veces cada una, con `Source-Date` mal atribuida. No ha llegado a pasar porque el job moría antes de commitear, pero un run completo tras el fix del 400 habría escrito esa historia — y deshacerla es filter-branch.

## El arreglo

Finlex **no ofrece corte superior**. Verifiqué ocho candidatos — `publishedBefore`, `publishedUntil`, `publishedTo`, `publishedMax`, `modifiedBefore`, `dateTo`, `endDate`, `publishedEnd` — y los ocho devuelven exactamente el mismo recuento que sin filtro: se aceptan y se ignoran en silencio. Un 200 no prueba nada en esta API.

Tampoco se puede acotar en cliente: los items de la lista traen solo `akn_uri` y `status`, sin ninguna fecha.

Queda la diferencia entre dos consultas acumulativas:

```py
on_or_after = self._ids_since(client, target_date)
later       = set(self._ids_since(client, target_date + timedelta(days=1)))
yield from (n for n in on_or_after if n not in later)
```

El límite superior de un día es el conjunto del día siguiente, así que se cachea: un recorrido hacia delante paga **una paginación por fecha**, no dos. La caché se poda a las dos entradas vivas, así que no crece con la ventana.

Efecto en la ventana de 9 días: **857 fetches en vez de 6.394**, más ~726 peticiones de paginación (inevitables: la API tope a 10 items/página y no hay corte superior). ~20 min, dentro del presupuesto.

Una norma tocada dos veces dentro de la ventana se emite una sola vez, el día de su última modificación.

## Verificación contra la API real

Con el código nuevo:

```
2026-08-10 ->  66 normas
2026-08-12 ->   0 normas
2026-08-17 -> 791 normas
```

Coincide exactamente con la medición día a día hecha por separado.

## Tests

`tests/test_discovery_fi.py` reescrito: 8 tests, **6 fallan contra main**. El fake cliente reproduce la semántica acumulativa real (se construye desde `{día: [normas]}` y responde "todo desde D"), así que los tests fallarían igual si alguien revirtiera el acotado.

Cubre: solo los cambios del día, día tranquilo dentro de la ventana con masa acumulada pendiente, último día de la ventana, norma tocada dos veces (no puede commitearse dos veces bajo dos fechas), la ventana entera emitiendo cada norma exactamente una vez, una paginación nueva por día, y que la caché no crece. Se mantiene el test de la zona horaria de #84.

Suite completa: 1751 passed, 27 skipped.

## `at` es de la misma familia — no lo toco aquí

`fetcher/at/discovery.py:114` tiene el mismo patrón con un agravante. Su propio docstring dice que la API de RIS **ignora** el parámetro `Geaendert`, así que pide `ImRisSeit=EinerWoche` y filtra en cliente por fecha. Por cada día de la ventana repagina el conjunto entero de "cambios de la última semana".

Es menos grave que fi porque filtra antes de descargar: desperdicia peticiones de listado, no de contenido, y no corrompe fechas. Pero hay algo peor escondido ahí: **`EinerWoche` son 7 días y `MAX_LOOKBACK_DAYS` son 10**. Los tres días más antiguos de una ventana completa son estructuralmente invisibles para Austria — un agujero silencioso, no un timeout. Merece su propio issue.

Co-Authored-By: Claude <noreply@anthropic.com>