### PR TITLE
Declare what a file's body actually is (spec v0.3)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,9 +139,9 @@
         "filename": "ADDING_A_COUNTRY.md",
         "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
         "is_verified": false,
-        "line_number": 793
+        "line_number": 810
       }
     ]
   },
-  "generated_at": "2026-04-17T06:31:36Z"
+  "generated_at": "2026-08-21T15:56:27Z"
 }

--- a/ADDING_A_COUNTRY.md
+++ b/ADDING_A_COUNTRY.md
@@ -27,7 +27,8 @@ Step 0: Research
   ├─ 0.4 Formatting inventory     → checklist in RESEARCH-{CC}.md
   ├─ 0.5 Version history spike    → tests/fixtures/{code}/version-spike.txt
   │       ┌──────────────────────────────────────────────────────┐
-  │       │ GATE: ≥2 versions extracted with dates from 1 law.  │
+  │       │ GATE: ≥2 versions extracted with dates from 1 law,  │
+  │       │ and the source classified into one text_state.       │
   │       │ If not → stop and investigate. Do not write parser.  │
   │       └──────────────────────────────────────────────────────┘
   ├─ 0.6 Estimate scope           → paragraph in RESEARCH-{CC}.md
@@ -347,6 +348,20 @@ or any law your research shows has been reformed). Then:
 3. **Save the evidence** as `tests/fixtures/{code}/version-spike.txt` (a summary
    showing "version 1: date X, N paragraphs; version 2: date Y, N paragraphs; ...")
    so the quality review in Step 7 can reference it.
+4. **Classify the source** and record the answer in `RESEARCH-{CC}.md`. This is the
+   same evidence, read one more time:
+
+   ```
+   Does the source give the text with amendments incorporated?
+     no  → as_enacted
+     yes → Does it give that text at a past date?
+             yes → point_in_time   (the default; declare nothing)
+             no  → current
+   ```
+
+   Anything other than `point_in_time` is declared in `countries.py::TEXT_STATE`, in
+   the same PR that registers the fetcher. It is one line and it decides what every
+   published file of that country says about itself — see CLAUDE.md, "Output format".
 
 **If you cannot extract at least 2 distinct versions with dates for a single law,
 stop and investigate:**
@@ -360,7 +375,9 @@ stop and investigate:**
 
 **Why this step exists:** every country where we discovered version-access problems
 late (DE, UY) cost a full reprocess. Catching it here costs an hour. Finding it
-after a full bootstrap costs a week.
+after a full bootstrap costs a week. The classification in point 4 is the cheap
+half of the same lesson: DE and UY publish a current text with no dated history,
+and nothing in their files said so for two years.
 
 ### 0.6 Estimate total scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,17 @@ source: "https://www.boe.es/eli/es/c/1978/12/27/(1)"
 
 Country-specific extras go in an `extra` sub-mapping (or as additional frontmatter keys for fields downstream consumers need).
 
-**Commit message types:** `[bootstrap]`, `[reforma]`, `[nueva]`, `[derogacion]`, `[correccion]`, `[fix-pipeline]`
+**Text state (Legalize Format Spec v0.3).** A file must say what its body actually is. Declared once per country in `countries.py::TEXT_STATE`, overridable per norm via `NormMetadata.text_state`:
+
+| Value | The body is |
+|---|---|
+| `point_in_time` | the law as in force on `last_updated` |
+| `current` | the latest text the source publishes, whatever the commit's date |
+| `as_enacted` | the act as published; amendments are not incorporated |
+
+`point_in_time` is the default and is **never written to the frontmatter** — a file without the field is `point_in_time`, which is why adding a country to `TEXT_STATE` changes its published output and forgetting to is the safe failure. `current` and `as_enacted` also emit a static notice below the H1; `as_enacted` additionally emits `last_amendment` (the ID of the most recent amending act), which is what makes two amendments published on the same date produce two commits instead of one.
+
+**Commit message types:** `[bootstrap]`, `[reform]`, `[new]`, `[repeal]`, `[correction]`, `[fix-pipeline]` — the values of `CommitType` in `models.py`. (They were Spanish until spec v0.2; existing commits keep their original labels.)
 
 **Commit trailers:** `Source-Id`, `Source-Date`, `Norm-Id`
 

--- a/src/legalize/countries.py
+++ b/src/legalize/countries.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from legalize.models import TextState
+
 if TYPE_CHECKING:
     from legalize.fetcher.base import (
         LegislativeClient,
@@ -22,6 +24,34 @@ if TYPE_CHECKING:
 # ─── Registry ───
 # Each country maps to (module_path, class_name) for lazy imports.
 # This avoids importing all country modules at startup.
+
+# ─── Text state ───
+# What each country's file bodies actually are (Legalize Format Spec v0.3).
+#
+# Countries absent from this map are POINT_IN_TIME: their body is the law as in
+# force on the file's ``last_updated``. Only sources that cannot deliver that are
+# listed, which is why adding a country here is a deliberate act and forgetting
+# to is the safe failure. A parser may still override per norm via
+# ``NormMetadata.text_state``.
+#
+# Changing a value here changes the published output of that country and requires
+# reprocessing its repo — see CLAUDE.md, "Output format — FINAL". A country is
+# declared here in the same PR that registers its fetcher, never before.
+
+TEXT_STATE: dict[str, TextState] = {
+    "ad": TextState.AS_ENACTED,  # BOPA publishes acts, never a consolidated text
+    "de": TextState.CURRENT,  # gesetze-im-internet: current text, undated standangabe
+    "dk": TextState.AS_ENACTED,  # Retsinformation: each act is its own document
+    "gr": TextState.AS_ENACTED,  # each FEK A' issue is an atomic act
+    "se": TextState.CURRENT,  # SFS gives one current text + an amendment register
+    "uy": TextState.CURRENT,  # IMPO: consolidated text, single bootstrap point
+}
+
+
+def text_state_for(country_code: str) -> TextState:
+    """Country default text state. Absent means POINT_IN_TIME (spec v0.3)."""
+    return TEXT_STATE.get(country_code, TextState.POINT_IN_TIME)
+
 
 REGISTRY: dict[str, dict[str, tuple[str, str]]] = {
     "ad": {

--- a/src/legalize/models.py
+++ b/src/legalize/models.py
@@ -92,6 +92,22 @@ class NormStatus(str, Enum):
     EXPIRED = "expired"
 
 
+class TextState(str, Enum):
+    """What a file's body actually is (Legalize Format Spec v0.3).
+
+    Two different questions decide this: are the amendments incorporated into
+    the text, and does the text correspond to the date the file claims. A body
+    can be consolidated and still not be the law as it stood at that date.
+
+    POINT_IN_TIME is the default and is never written to the frontmatter — a
+    file without the field is the law as in force on its ``last_updated``.
+    """
+
+    POINT_IN_TIME = "point_in_time"  # the law as in force on last_updated
+    CURRENT = "current"  # the latest text the source publishes, whatever the date
+    AS_ENACTED = "as_enacted"  # the act as published; amendments not incorporated
+
+
 # ─────────────────────────────────────────────
 # XML model (blocks and versions)
 # ─────────────────────────────────────────────
@@ -156,6 +172,11 @@ class NormMetadata:
     subjects: tuple[str, ...] = ()
     summary: str = ""
     extra: tuple[tuple[str, str], ...] = ()  # Country-specific key-value pairs for frontmatter
+    # None → the country default from countries.TEXT_STATE. Set explicitly only
+    # to override one norm: inside a consolidated country there are individual
+    # norms the source never consolidated (ar tier 2, eu, lu, ch).
+    text_state: Optional[TextState] = None
+    last_amendment: Optional[str] = None  # official ID of the most recent amending act
 
 
 # ─────────────────────────────────────────────

--- a/src/legalize/pipeline.py
+++ b/src/legalize/pipeline.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+from dataclasses import replace
 from datetime import date
 from pathlib import Path
 
@@ -592,7 +593,8 @@ def commit_one(config: Config, country: str, norm_id: str, dry_run: bool = False
         is_first = reform == reforms[0]
         commit_type = CommitType.BOOTSTRAP if is_first else CommitType.REFORM
 
-        markdown = render_norm_at_date(metadata, blocks, reform.date, include_all=is_first)
+        norm_meta = metadata if is_first else replace(metadata, last_amendment=reform.norm_id)
+        markdown = render_norm_at_date(norm_meta, blocks, reform.date, include_all=is_first)
         changed = repo.write_and_add(file_path, markdown)
 
         if not changed and not is_first:
@@ -777,7 +779,10 @@ def commit_all_fast(
                 is_first = reform_idx == 0
                 commit_type = CommitType.BOOTSTRAP if is_first else CommitType.REFORM
 
-                markdown = render_norm_at_date(metadata, blocks, reform.date, include_all=is_first)
+                norm_meta = (
+                    metadata if is_first else replace(metadata, last_amendment=reform.norm_id)
+                )
+                markdown = render_norm_at_date(norm_meta, blocks, reform.date, include_all=is_first)
                 file_path = norm_to_filepath(metadata)
 
                 info = build_commit_info(commit_type, metadata, reform, blocks, file_path, markdown)

--- a/src/legalize/transformer/frontmatter.py
+++ b/src/legalize/transformer/frontmatter.py
@@ -56,7 +56,7 @@ def render_frontmatter(metadata: NormMetadata, version_date: date) -> str:
     state = metadata.text_state or text_state_for(metadata.country)
     if state is not TextState.POINT_IN_TIME:
         lines.append(f'text_state: "{state.value}"')
-        if state is TextState.AS_ENACTED and metadata.last_amendment:
+        if metadata.last_amendment:
             lines.append(f'last_amendment: "{_escape_yaml(metadata.last_amendment)}"')
 
     if metadata.department:

--- a/src/legalize/transformer/frontmatter.py
+++ b/src/legalize/transformer/frontmatter.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 from datetime import date
 
-from legalize.models import NormMetadata, NormStatus
+from legalize.countries import text_state_for
+from legalize.models import NormMetadata, NormStatus, TextState
 
 
 def render_frontmatter(metadata: NormMetadata, version_date: date) -> str:
@@ -49,6 +50,14 @@ def render_frontmatter(metadata: NormMetadata, version_date: date) -> str:
         f'status: "{status}"',
         f'source: "{metadata.source}"',
     ]
+
+    # Spec v0.3: emitted only when the body is not the law in force at
+    # last_updated, so files that already state the law correctly never change.
+    state = metadata.text_state or text_state_for(metadata.country)
+    if state is not TextState.POINT_IN_TIME:
+        lines.append(f'text_state: "{state.value}"')
+        if state is TextState.AS_ENACTED and metadata.last_amendment:
+            lines.append(f'last_amendment: "{_escape_yaml(metadata.last_amendment)}"')
 
     if metadata.department:
         lines.append(f'department: "{_escape_yaml(metadata.department)}"')

--- a/src/legalize/transformer/markdown.py
+++ b/src/legalize/transformer/markdown.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 from datetime import date
 from typing import Callable
 
-from legalize.models import Block, NormMetadata, Paragraph
+from legalize.countries import text_state_for
+from legalize.models import Block, NormMetadata, Paragraph, TextState
 from legalize.transformer.frontmatter import render_frontmatter
 from legalize.transformer.xml_parser import get_block_at_date
 
@@ -85,6 +86,27 @@ _SIMPLE_CSS_MAP: dict[str, Callable[[str], str]] = {
     "table": lambda t: f"{t}\n",
     "table_row": lambda t: f"{t}\n",
 }
+
+# ─────────────────────────────────────────────
+# Text-state notice (Legalize Format Spec v0.3)
+# ─────────────────────────────────────────────
+
+# Static on purpose: byte-identical in every file and every commit of a country.
+# Everything that changes when an amendment lands — the date, the amending act —
+# lives in the frontmatter, so the body of one of these files is written once at
+# bootstrap and never rewritten. A count here ("amended 95 times") would be wrong
+# on every later commit as soon as an older amendment is backfilled.
+_NOTICES: dict[TextState, str] = {
+    TextState.AS_ENACTED: (
+        "> **This is the law as enacted. Amendments are not incorporated below — each one is\n"
+        "> a separate file in this repository and a commit in this file's history.**\n"
+    ),
+    TextState.CURRENT: (
+        "> **This file always contains the latest consolidated text published by the source.\n"
+        "> It is not the text as it stood on the date of any given commit.**\n"
+    ),
+}
+
 
 # Paired classes: num + tit merge into one heading.
 _PAIRED_CLASSES: dict[str, tuple[str, str]] = {
@@ -152,6 +174,10 @@ def render_norm_at_date(
 
     title = metadata.title.rstrip(". ").strip()
     parts.append(f"# {title}\n\n")
+
+    notice = _NOTICES.get(metadata.text_state or text_state_for(metadata.country))
+    if notice:
+        parts.append(f"{notice}\n")
 
     for block in blocks:
         version = get_block_at_date(block, target_date)

--- a/tests/test_parser_uy.py
+++ b/tests/test_parser_uy.py
@@ -39,7 +39,8 @@ from legalize.fetcher.uy.parser import (
     _strip_control_chars,
     _table_to_markdown,
 )
-from legalize.models import NormMetadata
+from legalize.models import NormMetadata, TextState
+from legalize.transformer.markdown import _NOTICES
 from legalize.transformer.markdown import render_norm_at_date
 from legalize.transformer.slug import norm_to_filepath
 
@@ -454,9 +455,16 @@ class TestEndToEndMarkdown:
 
     @pytest.mark.parametrize("fname", list(NORM_IDS))
     def test_no_blockquote_in_body(self, fname):
-        """We don't emit any blockquote — IMPO has no quoted amending text."""
+        """We don't emit any blockquote — IMPO has no quoted amending text.
+
+        The text-state notice is the one deliberate blockquote: IMPO publishes the
+        current consolidated text and no dated history, so every UY file is
+        ``current`` and opens with the notice (Legalize Format Spec v0.3).
+        """
         _meta, md = _render(fname)
-        body_lines = md.split("\n")
+        notice = _NOTICES[TextState.CURRENT]
+        assert notice in md, f"{fname}: missing the current-text notice"
+        body_lines = md.replace(notice, "").split("\n")
         # The frontmatter `---` markers are fine; check actual body lines
         in_body = False
         for line in body_lines:

--- a/tests/test_text_state.py
+++ b/tests/test_text_state.py
@@ -118,12 +118,18 @@ class TestCurrent:
         assert 'text_state: "current"' in md
         assert "It is not the text as it stood on the date of any given commit." in md
 
-    def test_last_amendment_is_not_emitted(self):
-        """Optional outside as_enacted, and Sweden's body carries no such claim."""
-        md = render_norm_at_date(
-            _norm("se", last_amendment="SFS-2026-1524"), _blocks(), date(2026, 1, 1)
+    def test_last_amendment_is_emitted(self):
+        """Sweden is why: its body is constant and its reform dates are all
+        1 January of the SFS year, so without this field two amendments from the
+        same year render identically and the pipeline drops the second commit."""
+        first = render_norm_at_date(
+            _norm("se", last_amendment="SFS 2024:397"), _blocks(), date(2024, 1, 1)
         )
-        assert "last_amendment" not in md
+        second = render_norm_at_date(
+            _norm("se", last_amendment="SFS 2024:1013"), _blocks(), date(2024, 1, 1)
+        )
+        assert 'last_amendment: "SFS 2024:397"' in first
+        assert first != second
 
 
 class TestPerNormOverride:

--- a/tests/test_text_state.py
+++ b/tests/test_text_state.py
@@ -1,0 +1,159 @@
+"""Text state — Legalize Format Spec v0.3.
+
+A file must say what its body actually is. Three cases exist and only two of
+them need saying, because a file with no ``text_state`` is the law as in force
+on its ``last_updated``.
+"""
+
+from datetime import date
+
+import pytest
+
+from legalize.countries import REGISTRY, TEXT_STATE, text_state_for
+from legalize.models import (
+    Block,
+    NormMetadata,
+    NormStatus,
+    Paragraph,
+    TextState,
+    Version,
+)
+from legalize.transformer.markdown import render_norm_at_date
+
+PUB = date(1981, 5, 7)
+
+
+def _norm(country: str, **kwargs) -> NormMetadata:
+    return NormMetadata(
+        title="Consumer Protection Law",
+        short_title="Consumer Protection Law",
+        identifier="2000123",
+        country=country,
+        rank="chok",
+        publication_date=PUB,
+        status=NormStatus.IN_FORCE,
+        department="Ministry of Economy",
+        source="https://example.test/2000123",
+        **kwargs,
+    )
+
+
+def _blocks() -> list[Block]:
+    return [
+        Block(
+            id="art-1",
+            block_type="articulo",
+            title="1",
+            versions=(
+                Version(
+                    norm_id="2000123",
+                    publication_date=PUB,
+                    effective_date=PUB,
+                    paragraphs=(Paragraph(css_class="articulo", text="Article 1"),),
+                ),
+            ),
+        )
+    ]
+
+
+def _body(md: str) -> str:
+    """Everything after the closing frontmatter delimiter."""
+    return md.split("\n---\n", 1)[1]
+
+
+class TestDefault:
+    def test_absent_country_is_point_in_time(self):
+        assert text_state_for("es") is TextState.POINT_IN_TIME
+        assert text_state_for("no-such-country") is TextState.POINT_IN_TIME
+
+    def test_point_in_time_emits_nothing(self):
+        md = render_norm_at_date(_norm("es"), _blocks(), date(2024, 2, 17))
+        assert "text_state" not in md
+        assert "last_amendment" not in md
+        assert ">" not in md.split("# ", 1)[1].split("\n")[1]
+
+    def test_point_in_time_ignores_last_amendment(self):
+        md = render_norm_at_date(
+            _norm("es", last_amendment="BOE-A-2024-3099"), _blocks(), date(2024, 2, 17)
+        )
+        assert "last_amendment" not in md
+
+
+class TestAsEnacted:
+    def test_frontmatter_and_notice(self):
+        md = render_norm_at_date(_norm("ad"), _blocks(), PUB)
+        assert 'text_state: "as_enacted"' in md
+        assert "This is the law as enacted." in md
+
+    def test_notice_sits_directly_under_the_title(self):
+        md = render_norm_at_date(_norm("ad"), _blocks(), PUB)
+        after_title = md.split("# Consumer Protection Law\n\n", 1)[1]
+        assert after_title.startswith("> **This is the law as enacted.")
+
+    def test_last_amendment_is_emitted(self):
+        md = render_norm_at_date(
+            _norm("ad", last_amendment="2243011"), _blocks(), date(2026, 3, 12)
+        )
+        assert 'last_amendment: "2243011"' in md
+
+    def test_body_is_identical_across_amendments(self):
+        """The whole point: an as_enacted body is written once and never rewritten.
+
+        Only the frontmatter moves when an amendment lands, so a reform commit is
+        a two-line diff and a backfilled amendment does not invalidate the text.
+        """
+        first = render_norm_at_date(
+            _norm("ad", last_amendment="2243011"), _blocks(), date(2026, 3, 12)
+        )
+        later = render_norm_at_date(
+            _norm("ad", last_amendment="2244136"), _blocks(), date(2026, 7, 28)
+        )
+        assert first != later
+        assert _body(first) == _body(later)
+
+
+class TestCurrent:
+    def test_frontmatter_and_notice(self):
+        md = render_norm_at_date(_norm("se"), _blocks(), date(2026, 1, 1))
+        assert 'text_state: "current"' in md
+        assert "It is not the text as it stood on the date of any given commit." in md
+
+    def test_last_amendment_is_not_emitted(self):
+        """Optional outside as_enacted, and Sweden's body carries no such claim."""
+        md = render_norm_at_date(
+            _norm("se", last_amendment="SFS-2026-1524"), _blocks(), date(2026, 1, 1)
+        )
+        assert "last_amendment" not in md
+
+
+class TestPerNormOverride:
+    def test_norm_overrides_its_country(self):
+        """A consolidated country still has norms the source never consolidated."""
+        md = render_norm_at_date(_norm("ar", text_state=TextState.AS_ENACTED), _blocks(), PUB)
+        assert 'text_state: "as_enacted"' in md
+
+    def test_norm_can_opt_back_into_the_default(self):
+        md = render_norm_at_date(_norm("se", text_state=TextState.POINT_IN_TIME), _blocks(), PUB)
+        assert "text_state" not in md
+
+
+class TestConformance:
+    """Every country declares the same thing in the same place."""
+
+    @pytest.mark.parametrize("code", sorted(TEXT_STATE))
+    def test_declared_country_is_registered(self, code):
+        assert code in REGISTRY, f"{code} declares a text_state but is not in REGISTRY"
+
+    @pytest.mark.parametrize("code", sorted(TEXT_STATE))
+    def test_declared_state_has_a_notice(self, code):
+        from legalize.transformer.markdown import _NOTICES
+
+        assert TEXT_STATE[code] in _NOTICES
+
+    def test_default_is_never_declared(self):
+        """point_in_time is the absence of a declaration, never a value."""
+        assert TextState.POINT_IN_TIME not in TEXT_STATE.values()
+
+    @pytest.mark.parametrize("code", sorted(REGISTRY))
+    def test_every_country_resolves(self, code):
+        assert isinstance(text_state_for(code), TextState)


### PR DESCRIPTION
Step 2 of #87. Implements [Legalize Format Spec v0.3](https://github.com/legalize-dev/legalize/blob/main/SPEC.md) (legalize-dev/legalize#20).

## The problem

A law file does not say what its own body is. Three different things are published across these repos and all three look identical:

| `text_state` | The body is | Countries |
|---|---|---|
| `point_in_time` | the law as in force on `last_updated` | es, fr, lt, co, uk, cz, sk, … |
| `current` | the latest text the source publishes, whatever the commit's date | se, de, uy |
| `as_enacted` | the act as published; amendments not incorporated | ad, dk, gr (il when it lands) |

Measured, not assumed: in `legalize-se`, commit `d0dfe869` on Brottsbalken is a **+1/−1 diff** touching only `last_updated`. The body has never changed, so the commit dated 1998 carries the 2026 text.

## How a country complies

It declares, it does not implement. One line in `countries.py`:

```python
TEXT_STATE: dict[str, TextState] = {
    "ad": TextState.AS_ENACTED,  # BOPA publishes acts, never a consolidated text
    "de": TextState.CURRENT,     # gesetze-im-internet: current text, undated standangabe
    ...
}
```

There is no per-country code and no interface to implement, deliberately — a hook each fetcher fills in is exactly how the four different behaviours in the table above came about. `transformer/` reads the declaration and renders; a country cannot render it differently because it does not render it.

`NormMetadata.text_state` overrides per norm, which is needed: inside consolidated countries there are individual norms the source never consolidated (`ar/client.py:150` tier 2, `eu/client.py:298`, `lu/client.py:299`, `ch/client.py:371`).

**Absent means `point_in_time`.** The ~29 countries that already state their law correctly emit nothing new and need no reprocessing. Adding a code to `TEXT_STATE` is what changes a country's output, so forgetting is the safe failure.

## The notice is static

`current` and `as_enacted` emit a fixed blockquote below the H1, byte-identical in every file and every commit. Everything that moves lives in the frontmatter, which buys two things:

1. An `as_enacted` body is written once at bootstrap and never rewritten. A reform commit is a two-line frontmatter diff.
2. A count in the body (*"amended 95 times"*) would be wrong on every later commit as soon as an older amendment is backfilled — and backfilling is expected. Israel went from 4 real reform dates out of 96 to 79 out of 95 once they were resolved in bulk.

## Side effect: Sweden stops losing amendments

`pipeline.py` skips the commit when the rendered file is unchanged. On a country whose body is constant, the only thing distinguishing two commits was `last_updated` — and Swedish reform dates are all 1 January of the SFS year. Every amendment after the first of each year silently disappeared:

```
d0dfe869 2026-01-01 [reform] Brottsbalk
a6a69f20 2025-01-01 [reform] Brottsbalk
4aa52920 2024-01-01 [reform] Brottsbalk
```

62 commits on the Swedish criminal code, exactly one per year. `last_amendment` in the frontmatter differs per act, so two amendments dated the same day now produce two commits.

## Also here

- **Step 0.5 gate** in `ADDING_A_COUNTRY.md` now requires classifying the source into one of the three states before the parser is written. DE and UY are the reason the gate exists; this is the cheap half of the same lesson.
- **`CLAUDE.md`** documents the field in the output-format contract, and its commit-type list is corrected to the English values actually emitted (`[reform]`, not `[reforma]`).
- **Conformance tests** assert that every declared country is in `REGISTRY`, that `point_in_time` is never declared as a value, and that an `as_enacted` body is identical across two different amendments. The first of those caught `il` being declared before its fetcher exists.

## Not in this PR

The DB column and API exposure, Israel, and reprocessing `se`/`de`/`uy`/`ad`/`gr` — steps 3 to 5 in #87. Merging this changes no country repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
