### PR TITLE
fix(ie): rewrite revised.py to use GitRepo + build_commit_info

### DIFF
--- a/scripts/fix_ie_revised_commits.py
+++ b/scripts/fix_ie_revised_commits.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Rewrite historical reformed commits in legalize-ie to match the standard format.
+
+The ~560 [reforma] commits created by the original revised.py used:
+  Subject: [reforma] IE-2024-act-7 — consolidated version 2024-03-15
+  Trailers: Source-Id=IE-2024-act-7, Norm-Id=IE-2024-act-7
+
+The standard format (from build_commit_info) should be:
+  Subject: [reform] Finance Act 2024
+  Trailers: Source-Id=revised-IE-2024-act-7, Norm-Id=IE-2024-act-7
+
+This script uses git filter-repo to fix the commit messages.
+
+⚠️  DESTRUCTIVE: This rewrites history. Requires force-push.
+
+Usage:
+    cd /path/to/legalize-ie
+    pip install git-filter-repo
+    python scripts/fix_ie_revised_commits.py
+    git push --force origin main
+
+Or dry-run (prints what would change):
+    python scripts/fix_ie_revised_commits.py --dry-run
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    dry_run = "--dry-run" in sys.argv
+
+    # Verify we're in a git repo
+    repo = Path.cwd()
+    if not (repo / ".git").exists():
+        print("Error: not in a git repo root. cd to legalize-ie first.")
+        sys.exit(1)
+
+    # Get all commits with [reforma] in the subject
+    result = subprocess.run(
+        [
+            "git", "log", "--all",
+            "--format=%H %s",
+            "--grep=\\[reforma\\]",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=repo,
+    )
+
+    commits = result.stdout.strip().splitlines()
+    if not commits:
+        print("No [reforma] commits found.")
+        return
+
+    print(f"Found {len(commits)} [reforma] commit(s) to rewrite.")
+
+    if dry_run:
+        print("\nDry-run — showing what would change:\n")
+        for line in commits[:10]:
+            sha, subject = line.split(" ", 1)
+            # Parse: [reforma] IE-2024-act-7 — consolidated version 2024-03-15
+            m = re.match(
+                r"\[reforma\]\s+(IE-\d{4}-act-\d+)\s+—\s+consolidated version\s+(.+)",
+                subject,
+            )
+            if m:
+                norm_id = m.group(1)
+                new_subject = f"[reform] {norm_id}"
+                print(f"  {sha[:8]}: {subject}")
+                print(f"        → {new_subject}")
+                print(f"        Source-Id: {norm_id} → revised-{norm_id}")
+                print()
+        if len(commits) > 10:
+            print(f"  ... and {len(commits) - 10} more")
+        print("\nRun without --dry-run to apply changes.")
+        return
+
+    # Create the message callback script for git filter-repo
+    callback_script = repo / ".git" / "_rewrite_callback.py"
+    callback_script.write_text(
+        '''
+import re
+
+def msg_callback(message):
+    msg = message.decode("utf-8", errors="replace")
+
+    # Fix subject: [reforma] IE-YYYY-act-N — consolidated version DATE
+    # →            [reform] IE-YYYY-act-N
+    m = re.match(
+        r"\\[reforma\\]\\s+(IE-\\d{4}-act-\\d+)\\s+—\\s+consolidated version\\s+(.+)",
+        msg.split("\\n")[0],
+    )
+    if not m:
+        return message  # Not a reforma commit, leave unchanged
+
+    norm_id = m.group(1)
+    lines = msg.split("\\n")
+
+    # Fix subject line
+    lines[0] = f"[reform] {norm_id}"
+
+    # Fix Source-Id trailer: norm_id → revised-norm_id
+    for i, line in enumerate(lines):
+        if line.startswith("Source-Id:"):
+            sid = line.split(":", 1)[1].strip()
+            if not sid.startswith("revised-"):
+                lines[i] = f"Source-Id: revised-{sid}"
+
+    return "\\n".join(lines).encode("utf-8")
+
+def commit_callback(commit):
+    commit.message = msg_callback(commit.message)
+'''
+    )
+
+    print("Running git filter-repo...")
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "git_filter_repo",
+            "--force",
+            "--commit-callback",
+            f"exec(open(r'{callback_script}').read()); commit_callback(commit)",
+        ],
+        cwd=repo,
+    )
+
+    if result.returncode == 0:
+        print("\n✓ History rewritten successfully.")
+        print("  Run: git push --force origin main")
+    else:
+        print(f"\n✗ git filter-repo failed with code {result.returncode}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/legalize/cli.py
+++ b/src/legalize/cli.py
@@ -376,6 +376,42 @@ def daily(
 
 
 # ─────────────────────────────────────────────
+# REVISED (Ireland only)
+# ─────────────────────────────────────────────
+
+
+@cli.command()
+@_country_option(default="ie")
+@click.option("--limit", default=None, type=int, help="Max norms to process.")
+@click.option("--dry-run", is_flag=True, help="Simulate without creating commits.")
+@click.pass_context
+def revised(
+    ctx: click.Context,
+    country: str,
+    limit: int | None,
+    dry_run: bool,
+) -> None:
+    """Apply Revised Acts consolidated versions (Ireland).
+
+    After bootstrap, fetches consolidated text from
+    revisedacts.lawreform.ie and creates REFORM commits.
+
+    Examples:
+        legalize revised                         # All revised acts
+        legalize revised --limit 10              # First 10 only
+        legalize revised --dry-run               # Simulate
+    """
+    if country != "ie":
+        console.print("[red]The 'revised' command is only available for Ireland (ie).[/red]")
+        return
+
+    from legalize.fetcher.ie.revised import apply_revised_acts
+
+    config = ctx.obj["config"]
+    apply_revised_acts(config, dry_run=dry_run, limit=limit)
+
+
+# ─────────────────────────────────────────────
 # REPROCESS
 # ─────────────────────────────────────────────
 

--- a/src/legalize/fetcher/ie/revised.py
+++ b/src/legalize/fetcher/ie/revised.py
@@ -4,22 +4,28 @@ After the initial bootstrap (enacted text), this module fetches
 consolidated text from revisedacts.lawreform.ie for the ~560 acts
 that have revised versions, and creates a second commit per law
 with the updated text.
+
+Uses the standard GitRepo + build_commit_info infrastructure for
+commit creation, ensuring consistent commit format, proper trailers,
+and idempotency via Source-Id checks.
 """
 
 from __future__ import annotations
 
 import logging
-import os
-import subprocess
 from datetime import date
 from pathlib import Path
 
 from rich.console import Console
 
+from legalize.committer.git_ops import GitRepo
+from legalize.committer.message import build_commit_info
 from legalize.config import Config
 from legalize.fetcher.ie.client import ISBClient
-from legalize.fetcher.ie.parser import parse_revised_html
-from legalize.transformer.markdown import render_paragraphs
+from legalize.fetcher.ie.parser import ISBMetadataParser, parse_revised_html
+from legalize.models import Block, CommitType, Reform, Version
+from legalize.transformer.markdown import render_norm_at_date
+from legalize.transformer.slug import norm_to_filepath
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -34,8 +40,12 @@ def apply_revised_acts(
     """Fetch and apply Revised Acts versions to the Ireland repo.
 
     For each norm in the repo, checks if a Revised Acts version exists.
-    If it does, overwrites the MD file with the consolidated text and
-    creates a REFORM commit dated at the "Updated to" date.
+    If it does, renders the consolidated text through the standard
+    pipeline (render_norm_at_date) and creates a REFORM commit via
+    GitRepo + build_commit_info.
+
+    Idempotency: checks has_commit_with_source_id before creating each
+    commit.  Safe to re-run.
 
     Returns the number of commits created.
     """
@@ -48,8 +58,15 @@ def apply_revised_acts(
 
     console.print("[bold]Revised Acts — applying consolidated versions[/bold]\n")
 
+    # Standard committer infrastructure
+    repo = GitRepo(repo_path, config.git.committer_name, config.git.committer_email)
+    repo.load_existing_commits()
+
+    metadata_parser = ISBMetadataParser()
+
     commits_created = 0
     revised_found = 0
+    skipped_idempotent = 0
     errors = 0
 
     with ISBClient.create(cc) as client:
@@ -59,6 +76,15 @@ def apply_revised_acts(
         for i, norm_id in enumerate(norm_ids):
             if limit and revised_found >= limit:
                 break
+
+            # Build the source ID for idempotency. Use a distinct prefix
+            # so Source-Id != Norm-Id (the report flags same-value as a bug).
+            source_id = f"revised-{norm_id}"
+
+            # Idempotency: skip if already committed
+            if repo.has_commit_with_source_id(source_id, norm_id):
+                skipped_idempotent += 1
+                continue
 
             # Try to fetch revised text
             try:
@@ -82,92 +108,67 @@ def apply_revised_acts(
             if updated_to is None:
                 updated_to = date.today()
 
-            # Render to markdown
-            md_content = render_paragraphs(paragraphs)
+            # Fetch metadata for this norm (needed for proper commit message)
+            try:
+                meta_data = client.get_metadata(norm_id)
+                metadata = metadata_parser.parse(meta_data, norm_id)
+            except Exception:
+                logger.debug("Could not fetch metadata for %s, using fallback", norm_id)
+                metadata = metadata_parser._fallback_metadata(norm_id)
 
-            # Read existing frontmatter from the enacted version
-            file_path = repo_path / "ie" / f"{norm_id}.md"
-            if not file_path.exists():
-                logger.debug("No enacted file for %s, skipping", norm_id)
-                continue
+            # Build Block/Version from revised paragraphs
+            block = Block(
+                id="full-text",
+                block_type="document",
+                title="",
+                versions=(
+                    Version(
+                        norm_id=norm_id,
+                        publication_date=updated_to,
+                        effective_date=updated_to,
+                        paragraphs=tuple(paragraphs),
+                    ),
+                ),
+            )
+            blocks = [block]
 
-            existing = file_path.read_text(encoding="utf-8")
-            # Extract frontmatter
-            if existing.startswith("---"):
-                parts = existing.split("---", 2)
-                if len(parts) >= 3:
-                    frontmatter = parts[1]
-                    # Update last_updated in frontmatter
-                    import re
-
-                    frontmatter = re.sub(
-                        r'last_updated: ".*?"',
-                        f'last_updated: "{updated_to.isoformat()}"',
-                        frontmatter,
-                    )
-                    new_content = f"---{frontmatter}---\n{md_content}\n"
-                else:
-                    new_content = f"{md_content}\n"
-            else:
-                new_content = f"{md_content}\n"
-
-            # Check if content actually changed
-            if new_content == existing:
-                logger.debug("No change for %s", norm_id)
-                continue
+            # Render to full markdown with frontmatter via standard pipeline
+            file_path = norm_to_filepath(metadata)
+            markdown = render_norm_at_date(
+                metadata, blocks, updated_to, include_all=True
+            )
 
             if dry_run:
-                console.print(f"  [yellow]DRY-RUN[/yellow] {norm_id} → revised {updated_to}")
+                console.print(
+                    f"  [yellow]DRY-RUN[/yellow] {norm_id} → revised {updated_to}"
+                )
                 commits_created += 1
                 continue
 
-            # Write updated content
-            file_path.write_text(new_content, encoding="utf-8")
-
-            # Git add + commit
-            rel_path = f"ie/{norm_id}.md"
-            subprocess.run(
-                ["git", "-C", str(repo_path), "add", rel_path],
-                check=True,
-                capture_output=True,
-            )
-
-            # Check if there's actually a diff staged
-            result = subprocess.run(
-                ["git", "-C", str(repo_path), "diff", "--cached", "--quiet"],
-                capture_output=True,
-            )
-            if result.returncode == 0:
-                # No changes staged
+            # Write and stage
+            changed = repo.write_and_add(file_path, markdown)
+            if not changed:
+                logger.debug("No change for %s", norm_id)
                 continue
 
-            commit_msg = f"[reforma] {norm_id} — consolidated version {updated_to}"
-            env = os.environ.copy()
-            env["GIT_AUTHOR_DATE"] = f"{updated_to.isoformat()}T12:00:00"
-            env["GIT_COMMITTER_DATE"] = f"{updated_to.isoformat()}T12:00:00"
-            env["GIT_COMMITTER_NAME"] = config.git.committer_name
-            env["GIT_COMMITTER_EMAIL"] = config.git.committer_email
-
-            subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(repo_path),
-                    "commit",
-                    "-m",
-                    commit_msg,
-                    "--trailer",
-                    f"Source-Id={norm_id}",
-                    "--trailer",
-                    f"Source-Date={updated_to.isoformat()}",
-                    "--trailer",
-                    f"Norm-Id={norm_id}",
-                ],
-                check=True,
-                capture_output=True,
-                env=env,
+            # Create reform and commit via standard infrastructure
+            reform = Reform(
+                date=updated_to,
+                norm_id=source_id,
+                affected_blocks=(),
             )
-            commits_created += 1
+            info = build_commit_info(
+                CommitType.REFORM,
+                metadata,
+                reform,
+                blocks,
+                file_path,
+                markdown,
+            )
+            sha = repo.commit(info)
+
+            if sha:
+                commits_created += 1
 
             if (revised_found % 50) == 0:
                 console.print(
@@ -179,6 +180,7 @@ def apply_revised_acts(
         f"\n[bold green]✓ Revised Acts complete[/bold green]\n"
         f"  {revised_found} revised versions found\n"
         f"  {commits_created} commits created\n"
+        f"  {skipped_idempotent} skipped (already committed)\n"
         f"  {errors} errors"
     )
     return commits_created


### PR DESCRIPTION
Replace subprocess git calls with the standard committer infrastructure:
- Uses GitRepo.write_and_add() + commit() instead of subprocess.run
- Uses build_commit_info(CommitType.REFORM, ...) for proper commit format with short_title in subject line
- Source-Id now uses 'revised-{norm_id}' prefix to distinguish from bootstrap commits (fixes Source-Id == Norm-Id bug)
- Uses render_norm_at_date() for full markdown with frontmatter instead of manual regex frontmatter patching
- Adds idempotency via has_commit_with_source_id() check
- Sets both GIT_AUTHOR_NAME/EMAIL and GIT_COMMITTER_NAME/EMAIL properly

Also adds:
- 'legalize revised' CLI subcommand (IE only)
- scripts/fix_ie_revised_commits.py for rewriting ~560 historical commits