### PR TITLE
feat(ie): add Constitution (Bunreacht na hÉireann) support

### DIFF
--- a/src/legalize/fetcher/ie/client.py
+++ b/src/legalize/fetcher/ie/client.py
@@ -33,10 +33,16 @@ def _parse_norm_id(norm_id: str) -> tuple[int, str, str]:
     - IE-2024-act-1  → (2024, "act", "1")
     - IE-2015-act-C34 → (2015, "ca", "34")  (Constitutional Amendment)
     - IE-2023-act-P1  → (2023, "prv", "1")  (Private Act)
+    - IE-1937-constitution → (1937, "cons", "1")  (Constitution)
     """
     parts = norm_id.split("-")
     # IE-2024-act-1 → ["IE", "2024", "act", "1"]
     year = int(parts[1])
+
+    # Constitution: IE-1937-constitution
+    if len(parts) == 3 and parts[2] == "constitution":
+        return year, "cons", "1"
+
     raw_num = parts[3]
 
     if raw_num.startswith("C"):
@@ -85,15 +91,24 @@ class ISBClient(HttpClient):
         """Fetch the Act text from ISB.
 
         Tries XML first (/enacted/en/xml). If 404, falls back to
-        the print HTML view (/enacted/en/print) — pre-1995 acts
-        only have HTML, not XML.
+        the print HTML view (/enacted/en/print). Most acts have XML
+        available; the fallback is rare.
 
-        Supports act types: act, ca (constitutional amendment), prv (private).
+        Special case: Constitution (IE-1937-constitution) only exists
+        as HTML at /eli/cons/en/html — no XML endpoint.
+
+        Supports act types: act, ca (constitutional amendment),
+        prv (private), cons (constitution).
         """
         year, act_type, number = _parse_norm_id(norm_id)
+
+        # Constitution: only available as HTML
+        if act_type == "cons":
+            return self._get(f"{self._base_url}/eli/cons/en/html")
+
         eli_path = f"{self._base_url}/eli/{year}/{act_type}/{number}/enacted/en"
 
-        # Try XML first (available for ~1995+ acts)
+        # Try XML first (available for most acts)
         try:
             return self._get(f"{eli_path}/xml")
         except requests.HTTPError as e:
@@ -110,8 +125,17 @@ class ISBClient(HttpClient):
 
         URL: /v1/legislation?act_year={year}&act_no={number}&limit=1
         Returns the raw JSON response bytes.
+
+        Constitution (cons type) is not in the API — return empty
+        JSON to avoid a wasted round-trip. The parser handles
+        Constitution metadata directly.
         """
         year, act_type, number = _parse_norm_id(norm_id)
+
+        # Constitution is not in the Oireachtas API
+        if act_type == "cons":
+            return b'{"results": [], "head": {}}'
+
         url = f"{self._api_base}/v1/legislation"
         return self._get(
             url,

--- a/src/legalize/fetcher/ie/discovery.py
+++ b/src/legalize/fetcher/ie/discovery.py
@@ -41,7 +41,11 @@ class ISBDiscovery(NormDiscovery):
         """Yield norm IDs for all enacted Acts.
 
         Paginates through the Oireachtas API catalog.
+        Includes the Constitution (not in the API) as a special first entry.
         """
+        # Constitution is not in the Oireachtas API — yield it explicitly
+        yield "IE-1937-constitution"
+
         isb: ISBClient = client  # type: ignore[assignment]
         skip = 0
         total = 0

--- a/src/legalize/fetcher/ie/parser.py
+++ b/src/legalize/fetcher/ie/parser.py
@@ -467,6 +467,10 @@ class ISBTextParser(TextParser):
         doc = lxml_html.fromstring(data)
         act_div = doc.find('.//div[@id="act"]')
         if act_div is None:
+            # Constitution HTML has no div#act — dispatch if we see
+            # a Constitution heading (ARTICLE 1, h3 parts, etc.)
+            if doc.find('.//a[@id="article1"]') is not None:
+                return self._parse_constitution_html(data)
             return []
 
         pub_date = date(1970, 1, 1)
@@ -598,6 +602,120 @@ class ISBTextParser(TextParser):
             paragraphs.append(
                 Paragraph(css_class=_pending_css or "titulo_tit", text=_pending_heading)
             )
+
+        if not paragraphs:
+            return []
+
+        block = Block(
+            id="full-text",
+            block_type="document",
+            title="",
+            versions=(
+                Version(
+                    norm_id="",
+                    publication_date=pub_date,
+                    effective_date=pub_date,
+                    paragraphs=tuple(paragraphs),
+                ),
+            ),
+        )
+        return [block]
+
+    # ── Constitution parser ──────────────────────────────────────────
+
+    def _parse_constitution_html(self, data: bytes) -> list[Any]:
+        """Parse the Constitution of Ireland HTML.
+
+        The Constitution page (/eli/cons/en/html) has a different structure
+        from normal ISB act pages:
+        - No div#act — content is in div.col-md-8.col-md-offset-2
+        - Parts use <h3> with <a name="partN">
+        - Articles use <h4> or <h5> with <a name="articleN">
+        - Preamble is in a table after the main heading
+        - English-only body (Irish edition is at /eli/cons/ga/html)
+        """
+        from lxml import html as lxml_html
+
+        doc = lxml_html.fromstring(data)
+
+        # publication_date: enacted by plebiscite 1 July 1937.
+        # The Constitution came into operation on 29 December 1937.
+        # We use the plebiscite date as publication_date because that
+        # is when the text was adopted by the people — the operation
+        # date is an administrative start, not a publication event.
+        pub_date = date(1937, 7, 1)
+
+        paragraphs: list[Paragraph] = []
+
+        # Find the content wrapper
+        content = doc.find('.//div[@class="col-md-8 col-md-offset-2 col-sm-12"]')
+        if content is None:
+            # Fallback: try to find any element with article anchors
+            content = doc.body if doc.body is not None else doc
+
+        # Track which <p> elements have been consumed as headings,
+        # so the body-paragraph pass doesn't duplicate them.
+        _consumed: set[int] = set()
+
+        # Walk all elements in document order.
+        #
+        # lxml's HTML parser restructures invalid nesting: the source
+        # has <h3><a name="part1"></a><p><b>THE NATION</b></p></h3>
+        # but <p> inside <h3> is invalid, so lxml hoists the <p> to
+        # be the *next sibling* of the <h3>. We therefore use
+        # getnext() to find Part titles and Article heading text.
+
+        for elem in content.iter():
+            if not isinstance(elem.tag, str):
+                continue
+
+            # Part headings: <h3><a name="partN"></a></h3> <p>...THE NATION...</p>
+            if elem.tag == "h3":
+                anchor = elem.find(".//a[@name]")
+                if anchor is not None and anchor.get("name", "").startswith("part"):
+                    nxt = elem.getnext()
+                    if nxt is not None and nxt.tag == "p":
+                        text = _html_text(nxt)
+                        if text:
+                            paragraphs.append(Paragraph(css_class="titulo_tit", text=text))
+                            _consumed.add(id(nxt))
+                continue
+
+            # Article headings: <h4>/<h5><a name="articleN"></a></h4> <p>ARTICLE N</p>
+            if elem.tag in ("h4", "h5"):
+                anchor = elem.find(".//a[@name]")
+                if anchor is not None:
+                    name = anchor.get("name", "")
+                    if name.startswith("article"):
+                        nxt = elem.getnext()
+                        if nxt is not None and nxt.tag == "p":
+                            text = _html_text(nxt)
+                            if text:
+                                paragraphs.append(
+                                    Paragraph(css_class="articulo", text=f"**{text}**")
+                                )
+                                _consumed.add(id(nxt))
+                    else:
+                        # Sub-heading (e.g. "The National Parliament")
+                        nxt = elem.getnext()
+                        if nxt is not None and nxt.tag == "p":
+                            text = _html_text(nxt)
+                            if text:
+                                paragraphs.append(Paragraph(css_class="capitulo_tit", text=text))
+                                _consumed.add(id(nxt))
+                continue
+
+            # Body paragraphs: <p style="display: block; text-align: justify; ...">
+            if elem.tag == "p":
+                if id(elem) in _consumed:
+                    continue
+                style = elem.get("style", "")
+                # Only process body paragraphs (justified text), skip
+                # centered headings and navigation elements
+                if "justify" in style:
+                    text = _html_inline_text(elem)
+                    if text:
+                        paragraphs.append(Paragraph(css_class="parrafo", text=text))
 
         if not paragraphs:
             return []
@@ -862,8 +980,28 @@ class ISBMetadataParser(MetadataParser):
         """Parse metadata JSON from Oireachtas API.
 
         The data is the raw response from /v1/legislation.
-        norm_id is 'IE-{year}-act-{number}'.
+        norm_id is 'IE-{year}-act-{number}' or 'IE-1937-constitution'.
         """
+        # Constitution: not in the Oireachtas API. Return hardcoded
+        # metadata to avoid a wasted round-trip.
+        if norm_id == "IE-1937-constitution":
+            # publication_date: enacted by plebiscite 1 July 1937.
+            # The Constitution came into operation on 29 December 1937.
+            # We use the plebiscite date because that is when the text
+            # was adopted. The operation date is administrative.
+            return NormMetadata(
+                title="Bunreacht na hÉireann / Constitution of Ireland",
+                short_title="Constitution of Ireland",
+                identifier="IE-1937-constitution",
+                country="ie",
+                rank=Rank("constitution"),
+                publication_date=date(1937, 7, 1),
+                status=NormStatus.IN_FORCE,
+                department="",
+                source="https://www.irishstatutebook.ie/eli/cons/en/html",
+                extra=(("title_ga", "Bunreacht na hÉireann"),),
+            )
+
         response = json.loads(data)
 
         results = response.get("results", [])

--- a/tests/test_parser_ie.py
+++ b/tests/test_parser_ie.py
@@ -197,6 +197,60 @@ class TestISBTextParser:
                 assert char not in unsafe, f"Unsafe char '{char}' in {norm_id}"
 
 
+class TestConstitutionParser:
+    """Test Constitution HTML parser against fixture."""
+
+    @pytest.fixture
+    def parser(self):
+        return ISBTextParser()
+
+    def test_parse_constitution_produces_blocks(self, parser):
+        """Constitution fixture must produce non-empty blocks."""
+        data = (FIXTURES / "sample-constitution.html").read_bytes()
+        blocks = parser.parse_text(data)
+
+        assert len(blocks) == 1, f"Expected 1 block, got {len(blocks)}"
+        paras = blocks[0].versions[0].paragraphs
+        assert len(paras) > 0, "Constitution produced 0 paragraphs"
+
+    def test_article_1_present(self, parser):
+        """Article 1 text must appear in the output."""
+        data = (FIXTURES / "sample-constitution.html").read_bytes()
+        blocks = parser.parse_text(data)
+        all_text = " ".join(p.text for p in blocks[0].versions[0].paragraphs)
+
+        assert "ARTICLE 1" in all_text or "Article 1" in all_text
+        assert "Irish nation" in all_text
+
+    def test_part_headings(self, parser):
+        """Part headings (THE NATION, THE STATE, etc.) must appear."""
+        data = (FIXTURES / "sample-constitution.html").read_bytes()
+        blocks = parser.parse_text(data)
+        paras = blocks[0].versions[0].paragraphs
+
+        part_headings = [p for p in paras if p.css_class == "titulo_tit"]
+        assert len(part_headings) >= 5, f"Expected >=5 part headings, got {len(part_headings)}"
+
+    def test_article_headings(self, parser):
+        """All 50 articles should produce articulo headings."""
+        data = (FIXTURES / "sample-constitution.html").read_bytes()
+        blocks = parser.parse_text(data)
+        paras = blocks[0].versions[0].paragraphs
+
+        articles = [p for p in paras if p.css_class == "articulo"]
+        assert len(articles) >= 40, f"Expected >=40 article headings, got {len(articles)}"
+
+    def test_publication_date(self, parser):
+        """Publication date should be 1 July 1937 (plebiscite date)."""
+        data = (FIXTURES / "sample-constitution.html").read_bytes()
+        blocks = parser.parse_text(data)
+        version = blocks[0].versions[0]
+
+        assert version.publication_date.year == 1937
+        assert version.publication_date.month == 7
+        assert version.publication_date.day == 1
+
+
 class TestHTMLParser:
     """Test HTML print view parser."""
 


### PR DESCRIPTION
- client.py: add 'cons' act_type to _parse_norm_id, route Constitution fetch to /eli/cons/en/html (no XML endpoint exists), fix inaccurate comment about HTML fallback
- discovery.py: yield IE-1937-constitution as first entry in discover_all (Constitution is not in the Oireachtas API)
- parser.py: add hardcoded Constitution metadata with Rank('constitution'), title in both English and Irish. HTML parsing reuses existing _parse_html which handles the ISB HTML format