### PR TITLE
fix(at): ask RIS for a change window that covers the whole lookback

### DIFF
--- a/src/legalize/fetcher/at/discovery.py
+++ b/src/legalize/fetcher/at/discovery.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from legalize.fetcher.base import LegislativeClient, NormDiscovery
 from legalize.fetcher.at.client import RISClient
+from legalize.state.store import MAX_LOOKBACK_DAYS
 
 logger = logging.getLogger(__name__)
 
@@ -17,12 +18,48 @@ logger = logging.getLogger(__name__)
 _CACHE_FILENAME = "gesetzesnummern.json"
 _CACHE_MAX_AGE_DAYS = 7
 
+# RIS ignores the Geaendert query parameter, so the daily asks for a coarse
+# change window and filters client-side. These are the windows the API accepts,
+# with the span each one covers.
+_RIS_WINDOWS = (
+    (7, "EinerWoche"),
+    (14, "ZweiWochen"),
+    (30, "EinemMonat"),
+    (90, "DreiMonaten"),
+    (180, "SechsMonaten"),
+    (365, "EinemJahr"),
+)
+
+
+def _ris_window(target_date: date) -> str:
+    """Smallest RIS change window that still reaches back to `target_date`.
+
+    Never narrower than the daily's own lookback. `EinerWoche` is 7 days while
+    `resolve_dates_to_process` walks back MAX_LOOKBACK_DAYS, so the oldest days
+    of every window asked for changes the query had never returned — and an
+    out-of-range date is not an error here, it is an empty result set, which is
+    why three days a run went missing without anyone noticing.
+    """
+    days = max((date.today() - target_date).days, MAX_LOOKBACK_DAYS) + 1
+    for span, name in _RIS_WINDOWS:
+        if span >= days:
+            return name
+    logger.warning(
+        "%s is %d days back; RIS looks back at most %d — changes may be missing",
+        target_date,
+        days,
+        _RIS_WINDOWS[-1][0],
+    )
+    return _RIS_WINDOWS[-1][1]
+
 
 class RISDiscovery(NormDiscovery):
     """Discovers all Gesetze (grouped by Gesetzesnummer) in the RIS catalog."""
 
     def __init__(self, cache_dir: str | None = None, **kwargs) -> None:
         self._cache_dir = cache_dir
+        # One fetch of the change window per run, keyed by window name.
+        self._recent: dict[str, list[tuple[str, str]]] = {}
 
     @classmethod
     def create(cls, source: dict) -> RISDiscovery:
@@ -114,20 +151,34 @@ class RISDiscovery(NormDiscovery):
     def discover_daily(
         self, client: LegislativeClient, target_date: date, **kwargs
     ) -> Iterator[str]:
-        """Yield Gesetzesnummern updated on target_date.
-
-        The RIS API ignores the Geaendert query parameter, so we use
-        ImRisSeit=EinerWoche to get recent changes and filter client-side
-        by the Allgemein.Geaendert field matching the target date.
-        """
+        """Yield Gesetzesnummern whose Geaendert date is target_date."""
         assert isinstance(client, RISClient)
-        seen: set[str] = set()
         date_str = target_date.strftime("%Y-%m-%d")
+        seen: set[str] = set()
+        for geaendert, gesnr in self._recent_changes(client, _ris_window(target_date)):
+            if geaendert == date_str and gesnr not in seen:
+                seen.add(gesnr)
+                yield gesnr
+
+    def _recent_changes(self, client: RISClient, window: str) -> list[tuple[str, str]]:
+        """(Geaendert, Gesetzesnummer) for every norm RIS reports in `window`.
+
+        Fetched once per run. `pipeline.daily` calls discover_daily once per
+        date of the lookback, and re-paginating the whole window for each of
+        them is what pushed the at job into its 55-minute timeout.
+        """
+        if window not in self._recent:
+            self._recent[window] = list(self._fetch_window(client, window))
+            logger.info("RIS window %s: %d changed norm(s)", window, len(self._recent[window]))
+        return self._recent[window]
+
+    @staticmethod
+    def _fetch_window(client: RISClient, window: str) -> Iterator[tuple[str, str]]:
         page = 1
         page_size = 100
 
         while True:
-            raw = client.get_page(page=page, page_size=page_size, ImRisSeit="EinerWoche")
+            raw = client.get_page(page=page, page_size=page_size, ImRisSeit=window)
             data = json.loads(raw)
             results = data["OgdSearchResult"].get("OgdDocumentResults")
             if not results:
@@ -140,13 +191,10 @@ class RISDiscovery(NormDiscovery):
 
             for ref in refs:
                 geaendert = ref["Data"]["Metadaten"].get("Allgemein", {}).get("Geaendert", "")
-                if geaendert != date_str:
-                    continue
                 br = ref["Data"]["Metadaten"]["Bundesrecht"]["BrKons"]
                 gesnr = br.get("Gesetzesnummer", "")
-                if gesnr and gesnr not in seen:
-                    seen.add(gesnr)
-                    yield gesnr
+                if gesnr:
+                    yield geaendert, gesnr
 
             fetched_so_far = (page - 1) * page_size + len(refs)
             if fetched_so_far >= total or not refs:

--- a/tests/test_daily_at.py
+++ b/tests/test_daily_at.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import json
 import subprocess
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from legalize.fetcher.at.client import RISClient
 from legalize.pipeline import generic_daily
-from legalize.state.store import infer_last_date_from_git
-from legalize.fetcher.at.discovery import RISDiscovery
+from legalize.state.store import MAX_LOOKBACK_DAYS, infer_last_date_from_git
+from legalize.fetcher.at.discovery import _RIS_WINDOWS, RISDiscovery, _ris_window
 
 
 # ─────────────────────────────────────────────
@@ -184,9 +184,43 @@ class TestRISDiscoverDaily:
         mock_client.get_page.return_value = _ris_empty_response()
 
         discovery = RISDiscovery()
-        list(discovery.discover_daily(mock_client, date(2026, 4, 1)))
+        list(discovery.discover_daily(mock_client, date.today()))
 
-        mock_client.get_page.assert_called_with(page=1, page_size=100, ImRisSeit="EinerWoche")
+        _, kwargs = mock_client.get_page.call_args
+        assert kwargs["ImRisSeit"] in dict(_RIS_WINDOWS).values()
+
+    def test_window_covers_the_whole_lookback(self):
+        """The window RIS is asked for must reach the oldest day the daily walks.
+
+        `EinerWoche` is 7 days and the daily walks back MAX_LOOKBACK_DAYS, so
+        its three oldest days used to ask for changes the query never returned
+        — no error, just nothing.
+        """
+        spans = dict((name, span) for span, name in _RIS_WINDOWS)
+        oldest = date.today() - timedelta(days=MAX_LOOKBACK_DAYS)
+
+        assert spans[_ris_window(oldest)] > MAX_LOOKBACK_DAYS
+
+    def test_an_older_explicit_date_widens_the_window(self):
+        spans = dict((name, span) for span, name in _RIS_WINDOWS)
+        recent = _ris_window(date.today() - timedelta(days=MAX_LOOKBACK_DAYS))
+        old = _ris_window(date.today() - timedelta(days=100))
+
+        assert spans[old] > spans[recent]
+
+    def test_the_window_is_fetched_once_for_the_whole_run(self):
+        """One pagination per run, not one per date — the 55-minute timeout."""
+        mock_client = self._mock_client()
+        mock_client.get_page.return_value = _ris_response(
+            hits=1, refs=[{"gesnr": "10002333"}], geaendert=date.today().isoformat()
+        )
+
+        discovery = RISDiscovery()
+        days = [date.today() - timedelta(days=n) for n in range(MAX_LOOKBACK_DAYS + 1)]
+        found = [gesnr for day in days for gesnr in discovery.discover_daily(mock_client, day)]
+
+        assert found == ["10002333"], "only the day that actually changed"
+        assert mock_client.get_page.call_count == 1
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #86.

## The bug

RIS ignores the `Geaendert` query parameter, so `discover_daily` asked for `ImRisSeit=EinerWoche` and filtered client-side. `EinerWoche` is 7 days; `resolve_dates_to_process` walks back `MAX_LOOKBACK_DAYS` (10, plus today = 11 days). The three oldest days of every run asked for changes the query had never returned.

It is silent because an out-of-range date is not an error — I checked, `ImRisSeit=Bogus` returns HTTP 200 with an empty result set, same as a window with nothing in it.

Measured against the live API today (2026-08-24):

```
EinerWoche  → 386 NOR,  75 laws, nothing older than 2026-08-17
ZweiWochen  → 520 NOR, 107 laws, reaches back to 2026-08-10
```

The oldest day of the lookback is 2026-08-14 and it holds **two changed laws, `20009888` and `20013275`**, that the daily could not see. 08-15 and 08-16 are a weekend, which is why the loss is only visible some runs.

## The fix

The window is derived from the date being asked for and is never narrower than the lookback, so the two constants cannot drift apart again. An explicit `--date` further back widens it rather than quietly returning nothing; past a year it warns instead of pretending.

It is also fetched **once per run** instead of once per date. Re-paginating the whole window for each of eleven days is the second half of the issue — the `timeout-minutes: 55` cancellation.

Same eleven days, same moment, real API:

| | listing requests | laws found | wall clock |
|---|---:|---:|---:|
| before | 44 | 78 | 36.5s |
| after | **6** | **80** | **5.0s** |

The two extra laws are the ones on 2026-08-14.

## Tests

`uv run pytest tests/ -q` → 1849 passed, 27 skipped.

`test_uses_imrisseit_filter` asserted the literal `"EinerWoche"`, which is the bug written down as an assertion; it now checks the value is one RIS accepts. Three new tests: the window covers the whole lookback, an older explicit date widens it, and the window is fetched once for the whole run.

Co-Authored-By: Claude <noreply@anthropic.com>